### PR TITLE
Fix bigint conversions in bucket settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 * Implement changing bucket settings, [PR-9](https://github.com/reduct-storage/web-console/pull/9)
 * Show error in CreateOrUpdate form if don't get settings, [PR-10](https://github.com/reduct-storage/web-console/pull/10)
 
+**Bugs**:
+
+* Fix bigint conversions in bucket settings, [PR-11](https://github.com/reduct-storage/web-console/pull/11)
+
 **Other**:
 
 * Update reduct-js to 0.4.0, [PR-6](https://github.com/reduct-storage/web-console/pull/6)

--- a/src/Components/Bucket/CreateOrUpdate.test.tsx
+++ b/src/Components/Bucket/CreateOrUpdate.test.tsx
@@ -49,7 +49,6 @@ describe("Bucket::Create", () => {
 
         const wrapper = mount(<CreateOrUpdate client={client} bucketName="bucket" onCreated={() => console.log("")}/>);
 
-
         await waitUntil(() => wrapper.update().find({name: "maxBlockSize"}).length > 0);
         expect(wrapper.find({name: "maxBlockSize"}).at(0).props().initialValue).toEqual("64");
         expect(wrapper.find({name: "quotaType"}).at(0).props().initialValue).toEqual("FIFO");


### PR DESCRIPTION
It doesn't work after webpack. See [here]( https://forum.dfinity.org/t/cannot-convert-a-bigint-value-to-a-number/5470/12)
```
2n ** BigInt(somvalue);
```