### PR TITLE
[#22] Fix timestamps for latest records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Timestamps for latest Bucket and Entry tables, [PR-24](https://github.com/reduct-storage/web-console/pull/24)
+
 ## [0.3.0]
 
 ### Added

--- a/src/Views/BucketPanel/BucketDetail.test.tsx
+++ b/src/Views/BucketPanel/BucketDetail.test.tsx
@@ -67,7 +67,7 @@ describe("BucketDetail", () => {
 
         expect(rows.length).toEqual(2);
         expect(rows.at(0).render().text())
-            .toEqual("EntryWithData100210 KB0 seconds1970-01-01T00:00:00.000Z1970-01-01T00:00:00.000Z");
+            .toEqual("EntryWithData100210 KB0 seconds1970-01-01T00:00:00.000Z1970-01-01T00:00:00.010Z");
         expect(rows.at(1).render().text())
             .toEqual("EmptyEntry000 B---------");
     });

--- a/src/Views/BucketPanel/BucketDetail.tsx
+++ b/src/Views/BucketPanel/BucketDetail.tsx
@@ -29,7 +29,7 @@ export default function BucketDetail(props: Readonly<Props>) {
 
     const data = entries.map(entry => {
         const printIsoDate = (timestamp: bigint) => entry.recordCount !== 0n ?
-            new Date(Number(entry.oldestRecord / 1000n)).toISOString() :
+            new Date(Number(timestamp / 1000n)).toISOString() :
             "---";
         return {
             name: entry.name,

--- a/src/Views/BucketPanel/BucketList.test.tsx
+++ b/src/Views/BucketPanel/BucketList.test.tsx
@@ -37,7 +37,7 @@ describe("BucketPanel", () => {
         const rows = panel.find(".ant-table-row");
         expect(rows.length).toEqual(2);
         expect(rows.at(0).render().text())
-            .toEqual("BucketWithData210 KB0 seconds1970-01-01T00:00:00.000Z1970-01-01T00:00:00.000Z");
+            .toEqual("BucketWithData210 KB0 seconds1970-01-01T00:00:00.000Z1970-01-01T00:00:00.010Z");
         expect(rows.at(1).render().text())
             .toEqual("EmptyBucket00 B---------");
 

--- a/src/Views/BucketPanel/BucketList.tsx
+++ b/src/Views/BucketPanel/BucketList.tsx
@@ -37,7 +37,7 @@ export default class BucketList extends React.Component<Props, State> {
         const {buckets} = this.state;
         const data = buckets.map(bucket => {
             const printIsoDate = (timestamp: bigint) => bucket.entryCount !== 0n ?
-                new Date(Number(bucket.oldestRecord / 1000n)).toISOString() :
+                new Date(Number(timestamp / 1000n)).toISOString() :
                 "---";
             return {
                 name: bucket.name,


### PR DESCRIPTION
Closes #22

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug Fix

### What is the current behavior?

We use same field `latestRecord` for  columns `Oldest Record (UTC)` and `Latest Record (UTC)`

### What is the new behavior?

We'll use fields `oldestRecord` and `latestRecords` 

### Does this PR introduce a breaking change?** 

No
