### PR TITLE
[#27] Sort buckets by latest record on dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added:
 
 - Make bucket card clickable to open bucket details, [PR-30](https://github.com/reduct-storage/web-console/pull/30)
-
+- Sorting buckets by latest record on dashboard, [PR-31](https://github.com/reduct-storage/web-console/pull/31)
 
 ### Changed:
 

--- a/src/Views/Dashboard/Dashboard.test.tsx
+++ b/src/Views/Dashboard/Dashboard.test.tsx
@@ -46,6 +46,12 @@ describe("Dashboard", () => {
             size: 1000n,
             oldestRecord: 10n,
             latestRecord: 10000010n,
+        }, {
+            name: "bucket_2",
+            entryCount: 2,
+            size: 1000n,
+            oldestRecord: 10n,
+            latestRecord: 10000030n,
         }
         ]);
     });
@@ -69,6 +75,15 @@ describe("Dashboard", () => {
         expect(bucket.text()).toContain("bucket_1");
         expect(bucket.text()).toContain("1 KB");
         expect(bucket.text()).toContain("10 seconds");
+    });
+
+    it("should order buckets by last records", async () => {
+        const wrapper = mount(<Dashboard backendApi={backend}/>);
+        let bucket = (await waitUntilFind(wrapper, "#bucket_1"));
+        expect(bucket.at(0).key()).toEqual("1");
+
+        bucket = (await waitUntilFind(wrapper, "#bucket_2"));
+        expect(bucket.at(0).key()).toEqual("0");
     });
 
     it("should push to BucketDetail if user click on bucket card", async () => {

--- a/src/Views/Dashboard/Dashboard.tsx
+++ b/src/Views/Dashboard/Dashboard.tsx
@@ -11,6 +11,7 @@ import CreateOrUpdate from "../../Components/Bucket/CreateOrUpdate";
 
 import {PlusOutlined} from "@ant-design/icons";
 import {useHistory} from "react-router-dom";
+import {History} from "history";
 
 interface Props {
     backendApi: IBackendAPI;
@@ -30,7 +31,8 @@ export default function Dashboard(props: Readonly<Props>) {
         try {
             const {client} = props.backendApi;
             setInfo(await client.getInfo());
-            setBuckets(await client.getBucketList());
+            setBuckets((await client.getBucketList())
+                .sort((a, b) => Number(b.latestRecord - a.latestRecord)));
         } catch (err) {
             console.error(err);
         }
@@ -45,11 +47,11 @@ export default function Dashboard(props: Readonly<Props>) {
         try {
             await getInfo();
         } catch (err) {
-            console.error(err);
+            console.error("Failed to remove %s : %s", name, err);
         }
     };
 
-    const showBucket = async (name: string, history: any) => {
+    const showBucket = async (name: string, history: History<unknown>) => {
         history.push(`/buckets/${name}`);
     };
 


### PR DESCRIPTION
Closes #27 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

On the dashboard, the buckets are sorted by names.

### What is the new behavior?

By last record, so recently updated is shown first.


### Does this PR introduce a breaking change?** 

No

### Other information:
