### PR TITLE
[#29] Add button to `Buckets` page to create a new bucket 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Make bucket card clickable to open bucket details, [PR-30](https://github.com/reduct-storage/web-console/pull/30)
 - Sorting buckets by latest record on dashboard, [PR-31](https://github.com/reduct-storage/web-console/pull/31)
+- Button to Buckets page to create a new bucket, [PR-32](https://github.com/reduct-storage/web-console/pull/32)
 
 ### Changed:
 
 - `reduct-js` version v0.6.0, [PR-30](https://github.com/reduct-storage/web-console/pull/30)
+- Disable control buttons of bucket card on Dashboard, [PR-32](https://github.com/reduct-storage/web-console/pull/32)
 
 ### Removed:
 
 - `crypto-browserify` dependency, [PR-30](https://github.com/reduct-storage/web-console/pull/30)
+
 ## [0.3.1]
 
 ### Fixed

--- a/src/Components/Bucket/BucketCard.test.tsx
+++ b/src/Components/Bucket/BucketCard.test.tsx
@@ -17,7 +17,7 @@ describe("BucketCard", () => {
         const client = new Client("");
         const onRemove = jest.fn();
 
-        const wrapper = mount(<BucketCard bucketInfo={info} client={client} index={0} onRemoved={onRemove} onShow={()=>null}/>);
+        const wrapper = mount(<BucketCard bucketInfo={info} enablePanel client={client} index={0} onRemoved={onRemove} onShow={()=>null}/>);
         const button = await waitUntilFind(wrapper, {title: "Settings"});
 
         button.hostNodes().simulate("click");

--- a/src/Components/Bucket/BucketCard.tsx
+++ b/src/Components/Bucket/BucketCard.tsx
@@ -14,6 +14,7 @@ interface Props {
     bucketInfo: BucketInfo;
     client: Client;
     index: number;
+    enablePanel?: boolean;
     onRemoved: (name: string) => void;
     onShow: (name: string) => void;
 }
@@ -42,14 +43,14 @@ export default function BucketCard(props: Readonly<Props>) {
         props.onRemoved(bucketInfo.name);
     };
 
-
+    const actions = props.enablePanel ? [
+        <SettingOutlined title="Settings" onClick={() => setChangeSettings(true)}/>,
+        <DeleteOutlined title="Remove" style={{color: "red"}} onClick={() => setConfirmRemove(true)}/>,
+    ] : [];
     return (<Card className="BucketCard" key={index} id={bucketInfo.name} title={bucketInfo.name}
-                  hoverable
+                  hoverable={props.enablePanel != true}
                   onClick={() => props.onShow(bucketInfo.name)}
-                  actions={[
-                      <SettingOutlined title="Settings" onClick={() => setChangeSettings(true)}/>,
-                      <DeleteOutlined title="Remove" onClick={() => setConfirmRemove(true)}/>,
-                  ]}>
+                  actions={actions}>
         <Row gutter={24}>
             <Col span={8}>
                 <Statistic title="Size" value={prettierBytes(n(bucketInfo.size))}/>

--- a/src/Helpers/TestHelpers.tsx
+++ b/src/Helpers/TestHelpers.tsx
@@ -2,7 +2,7 @@ import {createMemoryHistory} from "history";
 import {RouteComponentProps} from "react-router-dom";
 import waitUntil from "async-wait-until";
 import {ReactWrapper} from "enzyme";
-import {act} from "@testing-library/react";
+import {act} from "react-dom/test-utils";
 
 export const makeRouteProps = (): RouteComponentProps => {
     return {

--- a/src/Views/BucketPanel/BucketDetail.tsx
+++ b/src/Views/BucketPanel/BucketDetail.tsx
@@ -54,6 +54,7 @@ export default function BucketDetail(props: Readonly<Props>) {
 
     return <div style={{margin: "1.4em"}}>
         {info ? <BucketCard bucketInfo={info} index={0} client={props.client}
+                            enablePanel
                             onRemoved={() => history.push("/buckets")}
                             onShow={() => null}/> : <div/>}
 

--- a/src/Views/BucketPanel/BucketList.test.tsx
+++ b/src/Views/BucketPanel/BucketList.test.tsx
@@ -1,19 +1,18 @@
 import React from "react";
 import {mount} from "enzyme";
 import waitUntil from "async-wait-until";
-import {mockJSDOM} from "../../Helpers/TestHelpers";
+import {mockJSDOM, waitUntilFind} from "../../Helpers/TestHelpers";
 import BucketList from "./BucketList";
 import {BucketInfo, Client} from "reduct-js";
 import {MemoryRouter} from "react-router-dom";
+import {waitFor} from "@testing-library/react";
 
 describe("BucketPanel", () => {
+    const client = new Client("");
+
     beforeEach(() => {
         jest.clearAllMocks();
         mockJSDOM();
-    });
-
-    it("should print table with information about buckets", async () => {
-        const client = new Client("");
         client.getBucketList = jest.fn().mockResolvedValue([
             {
                 name: "BucketWithData",
@@ -30,7 +29,9 @@ describe("BucketPanel", () => {
                 latestRecord: 0n
             } as BucketInfo,
         ]);
+    });
 
+    it("should print table with information about buckets", async () => {
         const panel = mount(<MemoryRouter><BucketList client={client}/></MemoryRouter>);
         await waitUntil(() => panel.update().find(".ant-table-row").length > 0);
 
@@ -41,5 +42,13 @@ describe("BucketPanel", () => {
         expect(rows.at(1).render().text())
             .toEqual("EmptyBucket00 B---------");
 
+    });
+
+    it("should add a new bucket", async () => {
+        const panel = mount(<MemoryRouter><BucketList client={client}/></MemoryRouter>);
+        const button = await waitUntilFind(panel, {title: "Add"});
+        expect(button).toBeDefined();
+
+        // TODO: How to test modal?
     });
 });

--- a/src/Views/BucketPanel/BucketList.tsx
+++ b/src/Views/BucketPanel/BucketList.tsx
@@ -63,7 +63,7 @@ export default function BucketList(props: Readonly<Props>) {
         <Typography.Title level={3}>
             Buckets
             <Button style={{float: "right"}} icon={<PlusOutlined/>}
-                    onClick={() => setCreatingBucket(true)}>Add </Button>
+                    onClick={() => setCreatingBucket(true)} title="Add"/>
             <Modal title="Add a new bucket" visible={creatingBucket} footer={null}
                    onCancel={() => setCreatingBucket(false)}>
                 <CreateOrUpdate client={props.client}

--- a/src/Views/BucketPanel/BucketList.tsx
+++ b/src/Views/BucketPanel/BucketList.tsx
@@ -1,66 +1,78 @@
-import React from "react";
+import React, {useEffect, useState} from "react";
 import {BucketInfo, Client} from "reduct-js";
-import {Table, Typography} from "antd";
+import {Button, Modal, Table, Typography} from "antd";
 // @ts-ignore
 import prettierBytes from "prettier-bytes";
 
 import "../../App.css";
 import {getHistory} from "../../Components/Bucket/BucketCard";
 import {Link} from "react-router-dom";
+import {PlusOutlined} from "@ant-design/icons";
+import CreateOrUpdate from "../../Components/Bucket/CreateOrUpdate";
 
 
 interface Props {
     client: Client;
 }
 
-type State = {
-    buckets: BucketInfo[]
-};
 
 /**
  * Bucket View
  */
-export default class BucketList extends React.Component<Props, State> {
-    constructor(props: Readonly<Props>) {
-        super(props);
-        this.state = {buckets: []};
-    }
+export default function BucketList(props: Readonly<Props>) {
+    const [buckets, setBucckets] = useState<BucketInfo[]>([]);
+    const [creatingBucket, setCreatingBucket] = useState(false);
 
-    componentDidMount() {
-        const {client} = this.props;
+    useEffect(() => {
+        const {client} = props;
         client.getBucketList().then((buckets: BucketInfo[]) => {
-            this.setState({buckets});
+            setBucckets(buckets);
         });
-    }
+    }, [creatingBucket]);
 
-    render() {
-        const {buckets} = this.state;
-        const data = buckets.map(bucket => {
-            const printIsoDate = (timestamp: bigint) => bucket.entryCount !== 0n ?
-                new Date(Number(timestamp / 1000n)).toISOString() :
-                "---";
-            return {
-                name: bucket.name,
-                entryCount: bucket.entryCount.toString(),
-                size: prettierBytes(Number(bucket.size)),
-                history: bucket.entryCount !== 0n ? getHistory(bucket) : "---",
-                oldestRecord: printIsoDate(bucket.oldestRecord),
-                latestRecord: printIsoDate(bucket.latestRecord),
-            };
-        });
 
-        const columns = [
-            {title: "Name", dataIndex: "name", key: "name", render: (text: string) => <Link to={`buckets/${text}`}><b>{text}</b></Link>},
-            {title: "Entries", dataIndex: "entryCount", key: "entryCount"},
-            {title: "Size", dataIndex: "size", key: "size"},
-            {title: "History", dataIndex: "history", key: "history"},
-            {title: "Oldest Record (UTC)", dataIndex: "oldestRecord", key: "oldestRecord"},
-            {title: "Latest Record (UTC)", dataIndex: "latestRecord", key: "latestRecord"}
-        ];
+    const data = buckets.map(bucket => {
+        const printIsoDate = (timestamp: bigint) => bucket.entryCount !== 0n ?
+            new Date(Number(timestamp / 1000n)).toISOString() :
+            "---";
+        return {
+            name: bucket.name,
+            entryCount: bucket.entryCount.toString(),
+            size: prettierBytes(Number(bucket.size)),
+            history: bucket.entryCount !== 0n ? getHistory(bucket) : "---",
+            oldestRecord: printIsoDate(bucket.oldestRecord),
+            latestRecord: printIsoDate(bucket.latestRecord),
+        };
+    });
 
-        return <div style={{margin: "2em"}}>
-            <Typography.Title level={3}>Buckets</Typography.Title>
-            <Table columns={columns} dataSource={data} loading={buckets.length == 0}/>
-        </div>;
-    }
+    const columns = [
+        {
+            title: "Name",
+            dataIndex: "name",
+            key: "name",
+            render: (text: string) => <Link to={`buckets/${text}`}><b>{text}</b></Link>
+        },
+        {title: "Entries", dataIndex: "entryCount", key: "entryCount"},
+        {title: "Size", dataIndex: "size", key: "size"},
+        {title: "History", dataIndex: "history", key: "history"},
+        {title: "Oldest Record (UTC)", dataIndex: "oldestRecord", key: "oldestRecord"},
+        {title: "Latest Record (UTC)", dataIndex: "latestRecord", key: "latestRecord"}
+    ];
+
+    return <div style={{margin: "2em"}}>
+        <Typography.Title level={3}>
+            Buckets
+            <Button style={{float: "right"}} icon={<PlusOutlined/>}
+                    onClick={() => setCreatingBucket(true)}>Add </Button>
+            <Modal title="Add a new bucket" visible={creatingBucket} footer={null}
+                   onCancel={() => setCreatingBucket(false)}>
+                <CreateOrUpdate client={props.client}
+                                onCreated={async () => {
+                                    setCreatingBucket(false);
+                                }}/>
+            </Modal>
+
+        </Typography.Title>
+        <Table columns={columns} dataSource={data} loading={buckets.length == 0}/>
+    </div>;
 }

--- a/src/Views/Dashboard/Dashboard.tsx
+++ b/src/Views/Dashboard/Dashboard.tsx
@@ -40,7 +40,7 @@ export default function Dashboard(props: Readonly<Props>) {
 
     useEffect(() => {
         getInfo().catch(err => console.error(err));
-    }, []);
+    }, [creatingBucket]);
 
 
     const removeBucket = async (name: string) => {
@@ -106,7 +106,6 @@ export default function Dashboard(props: Readonly<Props>) {
                 <CreateOrUpdate client={client}
                                 onCreated={async () => {
                                     setCreatingBucket(false);
-                                    await getInfo();
                                 }}/>
             </Modal>
 


### PR DESCRIPTION
Closes #29

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Update

### What is the current behavior?

A user can add a new bucket only from dashboard

### What is the new behavior?

Now they can add it from `Buckets` page

### Does this PR introduce a breaking change?** 

No

### Other information:

Disable control panel on BucketCard on Dashboard. Now a user can change settings or remove a bucket only from its
detail view.