### PR TITLE
Update `reduct-js` to 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Validation for bucket name, [PR-39](https://github.com/reduct-storage/web-console/pull/39)
 - Input field to confirm bucket name before removing, [PR-40](https://github.com/reduct-storage/web-console/pull/40)
 
+### Changed:
+
+- Update `reduct-js` to 0.7.0, [PR-42](https://github.com/reduct-storage/web-console/pull/42) 
+
 ## [0.4.0] - 2022-08-21
 
 ### Added:

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "react-dom": "^17.0.0",
         "react-router-dom": "^5.3.3",
         "react-scripts": "5.0.1",
-        "reduct-js": "^0.6.0",
+        "reduct-js": "^0.7.0",
         "stream-browserify": "^3.0.0",
         "ts-jest": "^27.1.4",
         "typescript": "^4.6.3",
@@ -16109,9 +16109,9 @@
       }
     },
     "node_modules/reduct-js": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/reduct-js/-/reduct-js-0.6.0.tgz",
-      "integrity": "sha512-VXdtCUhC2i2DgAvpxvv9JUtJL3iJbZfvqp0EBoGA/v5jv3jGZfh5XNLAkutLE03Px3ol79UjuX6Dn7WJz9IOwQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/reduct-js/-/reduct-js-0.7.0.tgz",
+      "integrity": "sha512-fIYFlBy166wSPMIQf6hxYbkprTts9cSSTxFI3sJ9ASoH2z5WE/GYVS/OaMlkGAmUlX8zd1r4LTkaMQxace4qmg==",
       "dev": true,
       "dependencies": {
         "axios": "^0.27.2"
@@ -30925,9 +30925,9 @@
       }
     },
     "reduct-js": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/reduct-js/-/reduct-js-0.6.0.tgz",
-      "integrity": "sha512-VXdtCUhC2i2DgAvpxvv9JUtJL3iJbZfvqp0EBoGA/v5jv3jGZfh5XNLAkutLE03Px3ol79UjuX6Dn7WJz9IOwQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/reduct-js/-/reduct-js-0.7.0.tgz",
+      "integrity": "sha512-fIYFlBy166wSPMIQf6hxYbkprTts9cSSTxFI3sJ9ASoH2z5WE/GYVS/OaMlkGAmUlX8zd1r4LTkaMQxace4qmg==",
       "dev": true,
       "requires": {
         "axios": "^0.27.2"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react-dom": "^17.0.0",
     "react-router-dom": "^5.3.3",
     "react-scripts": "5.0.1",
-    "reduct-js": "^0.6.0",
+    "reduct-js": "^0.7.0",
     "ts-jest": "^27.1.4",
     "typescript": "^4.6.3",
     "web-vitals": "^2.1.4",


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Update

### What is the current behavior?

We use `reduct-js` == 0.6

### What is the new behavior?

 `reduct-js` == 0.7

### Does this PR introduce a breaking change?

No

### Other information:
