### PR TITLE
Update reduct-js to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed:
+
+- Update `reduct-js` to 1.0.0, [PR-43](https://github.com/reduct-storage/web-console/pull/43)
+
 ## [0.5.0] - 2022-09-14
 
 ### Added:

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "react-dom": "^17.0.0",
         "react-router-dom": "^5.3.3",
         "react-scripts": "5.0.1",
-        "reduct-js": "^0.7.0",
+        "reduct-js": "^1.0.0",
         "stream-browserify": "^3.0.0",
         "ts-jest": "^27.1.4",
         "typescript": "^4.6.3",
@@ -16109,9 +16109,9 @@
       }
     },
     "node_modules/reduct-js": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/reduct-js/-/reduct-js-0.7.0.tgz",
-      "integrity": "sha512-fIYFlBy166wSPMIQf6hxYbkprTts9cSSTxFI3sJ9ASoH2z5WE/GYVS/OaMlkGAmUlX8zd1r4LTkaMQxace4qmg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/reduct-js/-/reduct-js-1.0.0.tgz",
+      "integrity": "sha512-sUttiu1xNY5mD630iUAc+10kyYbj8gV29dm+lXH/fzJ0OQQs3vdxPFdd2E0ALG69yb/FpOW/hz/Jn/xNCFSfng==",
       "dev": true,
       "dependencies": {
         "axios": "^0.27.2"
@@ -30925,9 +30925,9 @@
       }
     },
     "reduct-js": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/reduct-js/-/reduct-js-0.7.0.tgz",
-      "integrity": "sha512-fIYFlBy166wSPMIQf6hxYbkprTts9cSSTxFI3sJ9ASoH2z5WE/GYVS/OaMlkGAmUlX8zd1r4LTkaMQxace4qmg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/reduct-js/-/reduct-js-1.0.0.tgz",
+      "integrity": "sha512-sUttiu1xNY5mD630iUAc+10kyYbj8gV29dm+lXH/fzJ0OQQs3vdxPFdd2E0ALG69yb/FpOW/hz/Jn/xNCFSfng==",
       "dev": true,
       "requires": {
         "axios": "^0.27.2"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react-dom": "^17.0.0",
     "react-router-dom": "^5.3.3",
     "react-scripts": "5.0.1",
-    "reduct-js": "^0.7.0",
+    "reduct-js": "^1.0.0",
     "ts-jest": "^27.1.4",
     "typescript": "^4.6.3",
     "web-vitals": "^2.1.4",


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Update

### What is the current behavior?

The console is using `reduct-js` 0l7 with experimental API

### What is the new behavior?

`reduct-js` v1.0.0 with new v1.0 HTT API support

### Does this PR introduce a breaking change?

No

### Other information:
