### PR TITLE
Patched reduct-js and release v1.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 1.14.1 - 2026-04-08
+
+### Fixed
+
+- update reduct-js to 1.19.1 to prevent "Illegal invocation" in browsers without global `fetch`, [PR-194](https://github.com/reductstore/web-console/pull/194)
+
 ## 1.14.0 - 2026-04-08
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.0.0",
-        "reduct-js": "^1.19.0",
+        "reduct-js": "^1.19.1",
         "typescript": "^6.0.0",
         "typescript-eslint": "^8.58.0",
         "vite": "^8.0.5",
@@ -4605,9 +4605,9 @@
       }
     },
     "node_modules/reduct-js": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/reduct-js/-/reduct-js-1.19.0.tgz",
-      "integrity": "sha512-jJZ9cBTQvjZYK76fuEKWbNCMEVJy7KFSY+aWD/sNk1abQSquLPF3KAw6oZ+v91tFb+C4WWABBxnvI0Lka2tJCA==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/reduct-js/-/reduct-js-1.19.1.tgz",
+      "integrity": "sha512-oi5WebeteTB2+VEe+mq3f51ObD0jG05f2YVam2hMAVB1UFmkakaHTXIhO6fuV15fDS0YdmtDWsYVhvkNidGBeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-console",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "type": "module",
   "private": true,
   "devDependencies": {
@@ -28,7 +28,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.0.0",
-    "reduct-js": "^1.19.0",
+    "reduct-js": "^1.19.1",
     "typescript": "^6.0.0",
     "typescript-eslint": "^8.58.0",
     "vite": "^8.0.5",


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

Patched reduct-js and release v1.14.1

### Related issues

https://github.com/reductstore/reduct-js/pull/162

### Does this PR introduce a breaking change?

No

### Other information:
