### PR TITLE
ci: enforce least-privilege GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - "v*"
   pull_request:
     branches: [main, stable]
+
+permissions: read-all
+
 jobs:
   format:
     runs-on: ubuntu-latest
@@ -86,6 +89,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test, e2e]
     if: ${{ (github.ref == 'refs/heads/main') || (startsWith(github.event.ref, 'refs/tags/v')) }}
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v2
       - name: Log in to the Container registry
@@ -114,6 +120,8 @@ jobs:
     needs: [test, e2e]
     name: Make release
     if: ${{ startsWith(github.event.ref, 'refs/tags/v') }}
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
       - uses: actions/create-release@v1


### PR DESCRIPTION
Closes #200

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

CI hardening / security improvement

### What was changed?

- Set workflow-level default token permissions to `read-all` in `.github/workflows/ci.yml`
- Added explicit job-level `permissions` for privileged jobs only:
  - `deploy`: `contents: read`, `packages: write` (for GHCR publish)
  - `make_release`: `contents: write` (for GitHub Release creation/upload)
- Left format/test/e2e jobs on read-only defaults

Plan reference: https://github.com/reductstore/web-console/issues/200#issuecomment-4351923403

### Related issues

- https://github.com/reductstore/web-console/issues/200
- Parent tracker: https://github.com/reductstore/security/issues/16

### Does this PR introduce a breaking change?

No.

### Other information:

Validation run locally:
- `npm run fmt:check`
- `npm run typecheck`
- `npm run test:ci`