### PR TITLE
203 feat support attachment with non json content types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Support binary (non-JSON) attachments with download, rename, and content type detection, [PR-204](https://github.com/reductstore/web-console/pull/204)
+
 ## 1.14.2 - 2026-04-15
 
 ### Fixed

--- a/src/Components/Entry/AttachmentEditor.tsx
+++ b/src/Components/Entry/AttachmentEditor.tsx
@@ -26,6 +26,8 @@ interface AttachmentEditorProps {
   initialValue?: string;
   /** Whether the editor is read-only */
   readOnly?: boolean;
+  /** Whether this is a binary attachment (no content editing) */
+  binaryMode?: boolean;
   /** Callback when save is clicked. Returns true if save succeeded. */
   onSave: (key: string, value: string) => Promise<boolean>;
   /** Callback when close/cancel is clicked */
@@ -46,6 +48,7 @@ const AttachmentEditor: React.FC<AttachmentEditorProps> = ({
   initialKey = "",
   initialValue = "",
   readOnly = false,
+  binaryMode = false,
   onSave,
   onClose,
   isSaving = false,
@@ -64,7 +67,9 @@ const AttachmentEditor: React.FC<AttachmentEditorProps> = ({
 
   const displayError = error ?? localError;
 
-  const hasChanges = name !== initialKey || content !== initialValue;
+  const hasChanges = binaryMode
+    ? name !== initialKey
+    : name !== initialKey || content !== initialValue;
 
   const validateJson = (value: string): string | null => {
     try {
@@ -83,7 +88,7 @@ const AttachmentEditor: React.FC<AttachmentEditorProps> = ({
   };
 
   const handleSave = async () => {
-    if (!readOnly && editorInstance) {
+    if (!readOnly && !binaryMode && editorInstance) {
       await editorInstance.getAction("editor.action.formatDocument")?.run();
     }
 
@@ -98,10 +103,12 @@ const AttachmentEditor: React.FC<AttachmentEditorProps> = ({
       return;
     }
 
-    const jsonError = validateJson(currentContent);
-    if (jsonError) {
-      setLocalError(`Invalid JSON: ${jsonError}`);
-      return;
+    if (!binaryMode) {
+      const jsonError = validateJson(currentContent);
+      if (jsonError) {
+        setLocalError(`Invalid JSON: ${jsonError}`);
+        return;
+      }
     }
 
     const success = await onSave(trimmedKey, currentContent);
@@ -197,54 +204,65 @@ const AttachmentEditor: React.FC<AttachmentEditorProps> = ({
           placeholder="Name"
           disabled={readOnly}
         />
-        <div
-          className={`monacoEditorWrapper${isDragOver ? " dragOver" : ""}${expanded ? " expanded" : ""}`}
-          onDrop={handleDrop}
-          onDragOver={handleDragOver}
-          onDragLeave={handleDragLeave}
-        >
-          {isDragOver && (
-            <div className="editorDropOverlay">
-              <Typography.Text type="secondary">
-                Drop JSON file here
-              </Typography.Text>
-            </div>
-          )}
-          <div className={`attachmentEditorBody${expanded ? " expanded" : ""}`}>
-            <Editor
-              height={expanded ? "100%" : `${editorHeight}px`}
-              language="json"
-              value={content}
-              onChange={handleContentChange}
-              onMount={(editor) => setEditorInstance(editor)}
-              options={{
-                minimap: { enabled: false },
-                lineNumbers: "on",
-                scrollBeyondLastLine: false,
-                wordWrap: "on",
-                automaticLayout: true,
-                folding: false,
-                glyphMargin: false,
-                lineDecorationsWidth: 10,
-                lineNumbersMinChars: 3,
-                renderLineHighlight: "none",
-                scrollbar: {
-                  vertical: "auto",
-                  horizontal: "hidden",
-                  verticalScrollbarSize: 8,
-                },
-                readOnly: readOnly,
-                quickSuggestions: false,
-                suggestOnTriggerCharacters: false,
-                parameterHints: { enabled: false },
-              }}
-            />
+        {binaryMode ? (
+          <div
+            className={`monacoEditorWrapper${expanded ? " expanded" : ""}`}
+            style={{ padding: "8px 12px" }}
+          >
+            <Typography.Text type="secondary" style={{ fontSize: 13 }}>
+              Format is not supported for preview
+            </Typography.Text>
           </div>
-        </div>
+        ) : (
+          <div
+            className={`monacoEditorWrapper${isDragOver ? " dragOver" : ""}${expanded ? " expanded" : ""}`}
+            onDrop={handleDrop}
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+          >
+            {isDragOver && (
+              <div className="editorDropOverlay">
+                <Typography.Text type="secondary">
+                  Drop JSON file here
+                </Typography.Text>
+              </div>
+            )}
+            <div className={`attachmentEditorBody${expanded ? " expanded" : ""}`}>
+              <Editor
+                height={expanded ? "100%" : `${editorHeight}px`}
+                language="json"
+                value={content}
+                onChange={handleContentChange}
+                onMount={(editor) => setEditorInstance(editor)}
+                options={{
+                  minimap: { enabled: false },
+                  lineNumbers: "on",
+                  scrollBeyondLastLine: false,
+                  wordWrap: "on",
+                  automaticLayout: true,
+                  folding: false,
+                  glyphMargin: false,
+                  lineDecorationsWidth: 10,
+                  lineNumbersMinChars: 3,
+                  renderLineHighlight: "none",
+                  scrollbar: {
+                    vertical: "auto",
+                    horizontal: "hidden",
+                    verticalScrollbarSize: 8,
+                  },
+                  readOnly: readOnly,
+                  quickSuggestions: false,
+                  suggestOnTriggerCharacters: false,
+                  parameterHints: { enabled: false },
+                }}
+              />
+            </div>
+          </div>
+        )}
       </div>
       <div className="attachmentEditorToolbar">
         <div className="attachmentEditorToolbarStatus">
-          {!readOnly && !displayError && (
+          {!readOnly && !binaryMode && !displayError && (
             <span className="dropHintText">
               <Typography.Text type="secondary">
                 Tip: drag & drop JSON file
@@ -282,17 +300,19 @@ const AttachmentEditor: React.FC<AttachmentEditorProps> = ({
               Save
             </Button>
           )}
-          <Tooltip
-            title={readOnly ? "Cannot format in read-only mode" : "Format JSON"}
-          >
-            <Button
-              size="small"
-              aria-label="Format JSON"
-              icon={<FormatPainterOutlined />}
-              onClick={handleFormat}
-              disabled={readOnly}
-            />
-          </Tooltip>
+          {!binaryMode && (
+            <Tooltip
+              title={readOnly ? "Cannot format in read-only mode" : "Format JSON"}
+            >
+              <Button
+                size="small"
+                aria-label="Format JSON"
+                icon={<FormatPainterOutlined />}
+                onClick={handleFormat}
+                disabled={readOnly}
+              />
+            </Tooltip>
+          )}
           {expandable && (
             <Tooltip title={isExpanded ? "Collapse editor" : "Expand editor"}>
               <Button

--- a/src/Components/Entry/AttachmentEditor.tsx
+++ b/src/Components/Entry/AttachmentEditor.tsx
@@ -227,7 +227,9 @@ const AttachmentEditor: React.FC<AttachmentEditorProps> = ({
                 </Typography.Text>
               </div>
             )}
-            <div className={`attachmentEditorBody${expanded ? " expanded" : ""}`}>
+            <div
+              className={`attachmentEditorBody${expanded ? " expanded" : ""}`}
+            >
               <Editor
                 height={expanded ? "100%" : `${editorHeight}px`}
                 language="json"
@@ -302,7 +304,9 @@ const AttachmentEditor: React.FC<AttachmentEditorProps> = ({
           )}
           {!binaryMode && (
             <Tooltip
-              title={readOnly ? "Cannot format in read-only mode" : "Format JSON"}
+              title={
+                readOnly ? "Cannot format in read-only mode" : "Format JSON"
+              }
             >
               <Button
                 size="small"

--- a/src/Components/Entry/EntryAttachmentsCard.css
+++ b/src/Components/Entry/EntryAttachmentsCard.css
@@ -72,11 +72,6 @@
   border-radius: 4px;
 }
 
-.contentPreview {
-  font-size: 12px;
-  font-family: monospace;
-}
-
 .rowActions {
   display: flex;
   align-items: center;
@@ -93,32 +88,6 @@
 }
 
 .actionIcon.saveIcon {
-  color: var(--primary-bg);
-}
-/* Filter dropdown styles */
-.filterDropdown {
-  padding: 8px;
-}
-
-.filterDropdown .filterInput {
-  margin-bottom: 8px;
-  display: block;
-}
-
-.filterDropdown .filterButton {
-  width: 90px;
-  margin-right: 8px;
-}
-
-.filterDropdown .resetButton {
-  width: 90px;
-}
-
-.filterIcon {
-  color: inherit;
-}
-
-.filterIcon.active {
   color: var(--primary-bg);
 }
 

--- a/src/Components/Entry/EntryAttachmentsCard.test.tsx
+++ b/src/Components/Entry/EntryAttachmentsCard.test.tsx
@@ -35,7 +35,9 @@ describe("EntryAttachmentsCard", () => {
   let container: HTMLElement;
 
   const makeBucket = () => ({
-    readAttachments: vi.fn().mockResolvedValue({ schema: { version: 1 } }),
+    readAttachmentsDetailed: vi.fn().mockResolvedValue({
+      schema: { value: { version: 1 }, contentType: "application/json" },
+    }),
     writeAttachments: vi.fn().mockResolvedValue(undefined),
     removeAttachments: vi.fn().mockResolvedValue(undefined),
   });
@@ -65,7 +67,7 @@ describe("EntryAttachmentsCard", () => {
     );
     ({ container } = result);
     await waitFor(() => {
-      expect(bucket.readAttachments).toHaveBeenCalled();
+      expect(bucket.readAttachmentsDetailed).toHaveBeenCalled();
     });
   };
 
@@ -73,7 +75,7 @@ describe("EntryAttachmentsCard", () => {
     await mountCard();
 
     expect(client.getBucket).toHaveBeenCalledWith("bucket");
-    expect(bucket.readAttachments).toHaveBeenCalledWith("entry");
+    expect(bucket.readAttachmentsDetailed).toHaveBeenCalledWith("entry");
     expect(container.textContent).toContain("schema");
     expect(container.textContent).toContain("Attachments");
   });
@@ -95,7 +97,7 @@ describe("EntryAttachmentsCard", () => {
   });
 
   it("shows 'No attachments' message when not editable and no attachments", async () => {
-    bucket.readAttachments.mockResolvedValue({});
+    bucket.readAttachmentsDetailed.mockResolvedValue({});
     await mountCard(false);
 
     await waitFor(() => {
@@ -104,7 +106,7 @@ describe("EntryAttachmentsCard", () => {
   });
 
   it("does not show 'No attachments' message when editable", async () => {
-    bucket.readAttachments.mockResolvedValue({});
+    bucket.readAttachmentsDetailed.mockResolvedValue({});
     await mountCard(true);
 
     expect(container.textContent).not.toContain("No attachments");
@@ -153,21 +155,6 @@ describe("EntryAttachmentsCard", () => {
     });
   });
 
-  it("truncates content preview to 50 characters", async () => {
-    const longValue = { data: "a".repeat(100) };
-    bucket.readAttachments.mockResolvedValueOnce({ longKey: longValue });
-    await mountCard();
-
-    await waitFor(() => {
-      const contentPreview = container.querySelector(
-        ".contentPreview",
-      ) as HTMLElement;
-      expect(contentPreview).toBeTruthy();
-      expect(contentPreview.textContent!.length).toBeLessThanOrEqual(50);
-      expect(contentPreview.textContent).toContain("...");
-    });
-  });
-
   it("has download button for attachments", async () => {
     await mountCard();
 
@@ -178,7 +165,9 @@ describe("EntryAttachmentsCard", () => {
 
   it("expands row to show full content", async () => {
     const testValue = { expanded: true, nested: { data: "test" } };
-    bucket.readAttachments.mockResolvedValueOnce({ testKey: testValue });
+    bucket.readAttachmentsDetailed.mockResolvedValueOnce({
+      testKey: { value: testValue, contentType: "application/json" },
+    });
     await mountCard();
 
     await waitFor(() => {
@@ -200,7 +189,9 @@ describe("EntryAttachmentsCard", () => {
 
   it("collapses expanded row on second click", async () => {
     const testValue = { expanded: true, nested: { data: "test".repeat(20) } };
-    bucket.readAttachments.mockResolvedValueOnce({ testKey: testValue });
+    bucket.readAttachmentsDetailed.mockResolvedValueOnce({
+      testKey: { value: testValue, contentType: "application/json" },
+    });
     await mountCard();
 
     await waitFor(() => {
@@ -361,14 +352,6 @@ describe("EntryAttachmentsCard", () => {
 
     await waitFor(() => {
       expect(container.querySelector(".ant-table-column-sorter")).toBeTruthy();
-    });
-  });
-
-  it("has search filter on key column", async () => {
-    await mountCard();
-
-    await waitFor(() => {
-      expect(container.querySelector(".filterIcon")).toBeTruthy();
     });
   });
 

--- a/src/Components/Entry/EntryAttachmentsCard.tsx
+++ b/src/Components/Entry/EntryAttachmentsCard.tsx
@@ -1,15 +1,16 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { Alert, Button, Input, Modal, Typography, message } from "antd";
+import { Alert, Button, Modal, Typography, message } from "antd";
 import type { ColumnType } from "antd/es/table";
 import {
   DeleteOutlined,
   UploadOutlined,
   DownloadOutlined,
-  SearchOutlined,
 } from "@ant-design/icons";
-import { APIError, Client } from "reduct-js";
+import { APIError, Client, AttachmentEntry } from "reduct-js";
+import prettierBytes from "prettier-bytes";
 import ScrollableTable from "../ScrollableTable";
 import { naturalNameSort } from "../../Views/BucketPanel/tree";
+import { getExtensionFromContentType } from "../../Helpers/contentType";
 import AttachmentEditor from "./AttachmentEditor";
 import "./EntryAttachmentsCard.css";
 
@@ -23,8 +24,10 @@ interface EntryAttachmentsCardProps {
 interface AttachmentTableRow {
   key: string;
   name: string;
-  content: string;
   rawValue: unknown;
+  contentType: string;
+  size: number;
+  isBinary: boolean;
 }
 
 interface EditingState {
@@ -36,11 +39,11 @@ const formatAttachmentValue = (value: unknown): string => {
   return JSON.stringify(value, null, 2);
 };
 
-const truncateContent = (value: unknown, maxLen = 50): string => {
-  const str = formatAttachmentValue(value);
-  const oneLine = str.replace(/\n/g, " ").replace(/\s+/g, " ");
-  if (oneLine.length <= maxLen) return oneLine;
-  return oneLine.slice(0, maxLen - 3) + "...";
+const isJsonContentType = (contentType: string): boolean => {
+  const ct = contentType.split(";")[0].trim().toLowerCase();
+  return (
+    ct === "application/json" || ct === "text/json" || ct.endsWith("+json")
+  );
 };
 
 const EntryAttachmentsCard: React.FC<EntryAttachmentsCardProps> = ({
@@ -49,7 +52,9 @@ const EntryAttachmentsCard: React.FC<EntryAttachmentsCardProps> = ({
   entryName,
   editable,
 }) => {
-  const [attachments, setAttachments] = useState<Record<string, unknown>>({});
+  const [attachments, setAttachments] = useState<
+    Record<string, AttachmentEntry>
+  >({});
   const [isLoading, setIsLoading] = useState(false);
   const [editing, setEditing] = useState<EditingState | null>(null);
   const [isSaving, setIsSaving] = useState(false);
@@ -63,7 +68,7 @@ const EntryAttachmentsCard: React.FC<EntryAttachmentsCardProps> = ({
     setIsLoading(true);
     try {
       const bucket = await client.getBucket(bucketName);
-      const data = await bucket.readAttachments(entryName);
+      const data = await bucket.readAttachmentsDetailed(entryName);
       setAttachments(data || {});
     } catch (err) {
       if (err instanceof APIError) {
@@ -124,19 +129,11 @@ const EntryAttachmentsCard: React.FC<EntryAttachmentsCardProps> = ({
 
     try {
       const bucket = await client.getBucket(bucketName);
-      const updated: Record<string, unknown> = {};
-      for (const [k, v] of Object.entries(attachments)) {
-        if (k === originalName) continue;
-        updated[k] = v;
-      }
-      updated[trimmedKey] = parsedValue;
+      await bucket.writeAttachments(entryName, { [trimmedKey]: parsedValue });
 
       if (originalName !== trimmedKey && originalName in attachments) {
         await bucket.removeAttachments(entryName, [originalName]);
       }
-
-      await bucket.writeAttachments(entryName, updated);
-      setAttachments(updated);
       setExpandedRowKeys((keys) => keys.filter((key) => key !== originalName));
       clearRowError(originalName);
       message.success("Attachment saved");
@@ -157,17 +154,79 @@ const EntryAttachmentsCard: React.FC<EntryAttachmentsCardProps> = ({
     }
   };
 
-  const downloadAttachment = (name: string, value: unknown) => {
-    const json = JSON.stringify(value, null, 2);
-    const blob = new Blob([json], { type: "application/json" });
-    const url = URL.createObjectURL(blob);
+  const renameAttachment = async (
+    originalName: string,
+    newName: string,
+    contentType: string,
+  ): Promise<boolean> => {
+    const trimmedName = newName.trim();
+    if (!trimmedName || trimmedName === originalName) return false;
+    if (trimmedName in attachments) {
+      setRowErrors((prev) => ({
+        ...prev,
+        [originalName]: `Name '${trimmedName}' already exists.`,
+      }));
+      return false;
+    }
+
+    setIsSaving(true);
+    try {
+      const bucket = await client.getBucket(bucketName);
+      const entry = attachments[originalName];
+      await bucket.writeAttachments(
+        entryName,
+        { [trimmedName]: entry.value },
+        contentType,
+      );
+      await bucket.removeAttachments(entryName, [originalName]);
+      setExpandedRowKeys((keys) => keys.filter((key) => key !== originalName));
+      clearRowError(originalName);
+      message.success("Attachment renamed");
+      await loadAttachments();
+      return true;
+    } catch (err) {
+      const errorMsg =
+        err instanceof APIError
+          ? err.message || "Failed to rename attachment."
+          : "Failed to rename attachment.";
+      setRowErrors((prev) => ({
+        ...prev,
+        [originalName]: errorMsg,
+      }));
+      return false;
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const downloadAttachment = (name: string, row: AttachmentTableRow) => {
     const a = document.createElement("a");
-    a.href = url;
-    a.download = `${name}.json`;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
+    if (row.isBinary) {
+      const binary = atob(row.rawValue as string);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) {
+        bytes[i] = binary.charCodeAt(i);
+      }
+      const blob = new Blob([bytes], { type: row.contentType });
+      const url = URL.createObjectURL(blob);
+      a.href = url;
+      const ext = getExtensionFromContentType(row.contentType);
+      a.download = name.includes(".") ? name : `${name}${ext}`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } else {
+      const json = JSON.stringify(row.rawValue, null, 2);
+      const blob = new Blob([json], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      a.href = url;
+      a.download = `${name}.json`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    }
   };
 
   const saveNewAttachment = async (
@@ -193,11 +252,7 @@ const EntryAttachmentsCard: React.FC<EntryAttachmentsCardProps> = ({
 
     try {
       const bucket = await client.getBucket(bucketName);
-      const updated: Record<string, unknown> = { ...attachments };
-      updated[trimmedKey] = parsedValue;
-
-      await bucket.writeAttachments(entryName, updated);
-      setAttachments(updated);
+      await bucket.writeAttachments(entryName, { [trimmedKey]: parsedValue });
       setEditing(null);
       setAddError(null);
       message.success("Attachment saved");
@@ -219,9 +274,6 @@ const EntryAttachmentsCard: React.FC<EntryAttachmentsCardProps> = ({
     const bucket = await client.getBucket(bucketName);
     await bucket.removeAttachments(entryName, [key]);
     message.success("Attachment removed");
-    const updated = { ...attachments };
-    delete updated[key];
-    setAttachments(updated);
     if (editing?.originalKey === key) {
       setEditing(null);
     }
@@ -231,12 +283,20 @@ const EntryAttachmentsCard: React.FC<EntryAttachmentsCardProps> = ({
   const attachmentEntries = Object.entries(attachments);
 
   const tableData: AttachmentTableRow[] = attachmentEntries.map(
-    ([name, value]) => ({
-      key: name,
-      name,
-      content: truncateContent(value),
-      rawValue: value,
-    }),
+    ([name, entry]) => {
+      const isBinary = !isJsonContentType(entry.contentType);
+      const size = isBinary
+        ? Math.floor(((entry.value as string).length * 3) / 4)
+        : new Blob([JSON.stringify(entry.value)]).size;
+      return {
+        key: name,
+        name,
+        rawValue: entry.value,
+        contentType: entry.contentType,
+        size,
+        isBinary,
+      };
+    },
   );
 
   const isAddingNew = editing !== null && editing.originalKey === null;
@@ -246,67 +306,21 @@ const EntryAttachmentsCard: React.FC<EntryAttachmentsCardProps> = ({
       title: "Name",
       dataIndex: "name",
       key: "name",
-      width: 200,
       sorter: (a, b) => naturalNameSort(a.name, b.name),
       showSorterTooltip: false,
-      filterDropdown: ({
-        setSelectedKeys,
-        selectedKeys,
-        confirm,
-        clearFilters,
-      }) => (
-        <div className="filterDropdown">
-          <Input
-            placeholder="Search key"
-            value={selectedKeys[0]}
-            onChange={(e) =>
-              setSelectedKeys(e.target.value ? [e.target.value] : [])
-            }
-            onPressEnter={() => confirm()}
-            className="filterInput"
-          />
-          <Button
-            type="primary"
-            onClick={() => confirm()}
-            icon={<SearchOutlined />}
-            size="small"
-            className="filterButton"
-          >
-            Search
-          </Button>
-          <Button
-            onClick={() => clearFilters?.()}
-            size="small"
-            className="resetButton"
-          >
-            Reset
-          </Button>
-        </div>
-      ),
-      filterIcon: (filtered) => (
-        <SearchOutlined className={`filterIcon${filtered ? " active" : ""}`} />
-      ),
-      onFilter: (value, record) =>
-        record.name.toLowerCase().includes((value as string).toLowerCase()),
-      render: (text: string) => {
-        return (
-          <Typography.Text strong style={{ fontSize: 13 }}>
-            {text}
-          </Typography.Text>
-        );
-      },
     },
     {
-      title: "Content",
-      dataIndex: "content",
-      key: "content",
-      render: (text: string) => {
-        return (
-          <Typography.Text type="secondary" className="contentPreview">
-            {text}
-          </Typography.Text>
-        );
-      },
+      title: "Size",
+      dataIndex: "size",
+      key: "size",
+      sorter: (a, b) => a.size - b.size,
+      showSorterTooltip: false,
+      render: (_: number, row: AttachmentTableRow) => prettierBytes(row.size),
+    },
+    {
+      title: "Content Type",
+      dataIndex: "contentType",
+      key: "contentType",
     },
   ];
 
@@ -322,7 +336,7 @@ const EntryAttachmentsCard: React.FC<EntryAttachmentsCardProps> = ({
             size="small"
             icon={<DownloadOutlined />}
             title="Download"
-            onClick={() => downloadAttachment(row.name, row.rawValue)}
+            onClick={() => downloadAttachment(row.name, row)}
             className="actionIcon"
           />
           {editable && (
@@ -389,7 +403,7 @@ const EntryAttachmentsCard: React.FC<EntryAttachmentsCardProps> = ({
 
       {hasAttachments && (
         <ScrollableTable
-          scroll={{ x: "max-content" }}
+          scroll={{ x: true }}
           columns={columns}
           dataSource={tableData}
           size="small"
@@ -408,6 +422,28 @@ const EntryAttachmentsCard: React.FC<EntryAttachmentsCardProps> = ({
               setExpandedRowKeys(newKeys);
             },
             expandedRowRender: (record: AttachmentTableRow) => {
+              if (record.isBinary) {
+                return (
+                  <AttachmentEditor
+                    initialKey={record.name}
+                    initialValue=""
+                    readOnly={!editable}
+                    binaryMode
+                    onSave={(key) =>
+                      renameAttachment(record.name, key, record.contentType)
+                    }
+                    onClose={() => {
+                      setExpandedRowKeys((keys) =>
+                        keys.filter((key) => key !== record.name),
+                      );
+                      clearRowError(record.name);
+                    }}
+                    isSaving={isSaving}
+                    error={rowErrors[record.name]}
+                    onClearError={() => clearRowError(record.name)}
+                  />
+                );
+              }
               return (
                 <AttachmentEditor
                   initialKey={record.name}

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,3 +1,7 @@
+declare module "prettier-bytes" {
+  export default function prettierBytes(bytes: number): string;
+}
+
 declare namespace NodeJS {
   interface ProcessEnv {
     readonly NODE_ENV: "development" | "production" | "test";


### PR DESCRIPTION
Closes #203 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

Support binary (non-JSON) attachments with download, rename, and content type detection

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
