### PR TITLE
Pin Docker GitHub Actions to latest stable SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -103,12 +103,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ghcr.io/${{github.repository}}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           push: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
       - run: npm ci
@@ -25,8 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: format
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
       - name: Install modules
@@ -54,8 +54,8 @@ jobs:
         env:
           RS_CORS_ALLOW_ORIGIN: "*"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
       - run: npm ci
@@ -93,7 +93,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Log in to the Container registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
@@ -123,7 +123,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - uses: actions/create-release@v1
         id: create_release
         with:
@@ -135,7 +135,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Install modules
         run: npm install
       - name: Build app

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Pin Docker GitHub Actions to latest stable commit SHAs in CI workflows, [PR-205](https://github.com/reductstore/web-console/pull/205)
+
 ## 1.14.2 - 2026-04-15
 
 ### Fixed


### PR DESCRIPTION
Closes #202

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

CI/security hardening update.

### What was changed?

- Updated pinned SHA for `docker/login-action` to `v4.1.0` commit.
- Updated pinned SHA for `docker/metadata-action` to `v6.0.0` commit.
- Updated pinned SHA for `docker/build-push-action` to `v7.1.0` commit.
- Kept SHA pinning style and added inline release comments for traceability.

### Related issues

- https://github.com/reductstore/web-console/issues/202
- Parent tracking: https://github.com/reductstore/security/issues/22
- Approved implementation plan comment: https://github.com/reductstore/web-console/issues/202#issuecomment-2847446385

### Does this PR introduce a breaking change?

No breaking API/runtime change in product code. CI behavior may differ only if upstream Docker actions changed between pinned releases.

### Other information:

Validation run locally on this branch:
- `npm ci`
- `npm run fmt:check`
- `npm run lint`
