### PR TITLE
Add replication destination prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,6 @@ jobs:
     name: "End-to-end tests"
     runs-on: ubuntu-latest
     needs: format
-    env:
-      RS_API_TOKEN: e2e-token
     services:
       reductstore:
         image: reduct/store:main
@@ -55,7 +53,6 @@ jobs:
           - 8383:8383
         env:
           RS_CORS_ALLOW_ORIGIN: "*"
-          RS_API_TOKEN: e2e-token
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -67,7 +64,7 @@ jobs:
       - name: Wait for ReductStore API
         run: |
           for i in $(seq 1 30); do
-            if curl -fsS -H "Authorization: Bearer ${RS_API_TOKEN}" http://127.0.0.1:8383/api/v1/info >/dev/null; then
+            if curl -fsS http://127.0.0.1:8383/api/v1/info >/dev/null; then
               exit 0
             fi
             sleep 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
           - 8383:8383
         env:
           RS_CORS_ALLOW_ORIGIN: "*"
+          RS_API_TOKEN: e2e-token
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -76,6 +77,7 @@ jobs:
         run: npm run e2e
         env:
           RS_URL: http://127.0.0.1:8383
+          RS_API_TOKEN: e2e-token
       - name: Upload test artifacts
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
     name: "End-to-end tests"
     runs-on: ubuntu-latest
     needs: format
+    env:
+      RS_API_TOKEN: e2e-token
     services:
       reductstore:
         image: reduct/store:main
@@ -53,6 +55,7 @@ jobs:
           - 8383:8383
         env:
           RS_CORS_ALLOW_ORIGIN: "*"
+          RS_API_TOKEN: e2e-token
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -64,7 +67,7 @@ jobs:
       - name: Wait for ReductStore API
         run: |
           for i in $(seq 1 30); do
-            if curl -fsS http://127.0.0.1:8383/api/v1/info >/dev/null; then
+            if curl -fsS -H "Authorization: Bearer ${RS_API_TOKEN}" http://127.0.0.1:8383/api/v1/info >/dev/null; then
               exit 0
             fi
             sleep 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
     name: "End-to-end tests"
     runs-on: ubuntu-latest
     needs: format
+    env:
+      RS_API_TOKEN: e2e-token
     services:
       reductstore:
         image: reduct/store:main
@@ -65,7 +67,7 @@ jobs:
       - name: Wait for ReductStore API
         run: |
           for i in $(seq 1 30); do
-            if curl -fsS http://127.0.0.1:8383/api/v1/info >/dev/null; then
+            if curl -fsS -H "Authorization: Bearer ${RS_API_TOKEN}" http://127.0.0.1:8383/api/v1/info >/dev/null; then
               exit 0
             fi
             sleep 2
@@ -77,7 +79,6 @@ jobs:
         run: npm run e2e
         env:
           RS_URL: http://127.0.0.1:8383
-          RS_API_TOKEN: e2e-token
       - name: Upload test artifacts
         if: failure()
         uses: actions/upload-artifact@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,3 +8,7 @@
 ## Formatting
 
 - Format code: `npm run fmt`.
+
+## Git Workflow
+
+- Do not push changes yourself. Create commits only when a loaded repository skill explicitly requires them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Support destination entry prefixes for replications, [PR-XXX](https://github.com/reductstore/web-console/pull/XXX)
+- Support destination entry prefixes for replications, [PR-225](https://github.com/reductstore/web-console/pull/225)
 
 ## 1.15.1 - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Support destination entry prefixes for replications, [PR-XXX](https://github.com/reductstore/web-console/pull/XXX)
+
 ## 1.15.1 - 2026-06-19
 
 ### Fixed

--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,0 +1,5 @@
+{
+  "high": true,
+  "critical": true,
+  "allowlist": ["GHSA-qwww-vcr4-c8h2"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2252,15 +2252,15 @@
       }
     },
     "node_modules/@vitest/browser": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.8.tgz",
-      "integrity": "sha512-u21VzX07HzlJYpFgkxmjEXar/tG2UqWGgyGG/46SrrPc7rSdCTPw5vuowopO9CIqF8UCUQzDFdbVnNpw6N0BfQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.10.tgz",
+      "integrity": "sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@blazediff/core": "1.9.1",
-        "@vitest/mocker": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "magic-string": "^0.30.21",
         "pngjs": "^7.0.0",
         "sirv": "^3.0.2",
@@ -2271,20 +2271,20 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "4.1.8"
+        "vitest": "4.1.10"
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
-      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -2293,13 +2293,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
-      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.8",
+        "@vitest/spy": "4.1.10",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2320,9 +2320,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
-      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2333,13 +2333,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
-      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.8",
+        "@vitest/utils": "4.1.10",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2347,14 +2347,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
-      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2363,9 +2363,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
-      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2373,13 +2373,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
-      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
+        "@vitest/pretty-format": "4.1.10",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -2573,16 +2573,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer": {
@@ -2819,9 +2819,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -3093,9 +3093,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -3846,9 +3846,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -4009,9 +4009,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -4029,7 +4029,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -4154,9 +4154,9 @@
       "license": "MIT"
     },
     "node_modules/react-router": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
-      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4177,13 +4177,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
-      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.17.0"
+        "react-router": "7.18.2"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -4630,9 +4630,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4763,19 +4763,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
-      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.8",
-        "@vitest/mocker": "4.1.8",
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/runner": "4.1.8",
-        "@vitest/snapshot": "4.1.8",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -4803,12 +4803,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.8",
-        "@vitest/browser-preview": "4.1.8",
-        "@vitest/browser-webdriverio": "4.1.8",
-        "@vitest/coverage-istanbul": "4.1.8",
-        "@vitest/coverage-v8": "4.1.8",
-        "@vitest/ui": "4.1.8",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.0.0",
-        "reduct-js": "^1.20.0",
+        "reduct-js": "^1.21.0-beta.0",
         "typescript": "^6.0.0",
         "typescript-eslint": "^8.58.0",
         "vite": "^8.0.5",
@@ -4208,9 +4208,9 @@
       }
     },
     "node_modules/reduct-js": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/reduct-js/-/reduct-js-1.20.0.tgz",
-      "integrity": "sha512-wuTGR4slkUxekKtmdOKoiOm/i365VFPFDRxmDLI99St5X5Y0sSdGYvRMMx0P2d1nSGrLFhYNwChIYrvKn0W0Cg==",
+      "version": "1.21.0-beta.0",
+      "resolved": "https://registry.npmjs.org/reduct-js/-/reduct-js-1.21.0-beta.0.tgz",
+      "integrity": "sha512-D1ssIRG0uZNyyA4XK9dbMpJhdBKg3YBlZXaYmT20Clt9KiyBQn2X3/NWlU3wVl9jzV0UXDY3E2V3kfDRu53dRw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/browser": "^4.1.2",
         "antd": "^6.0.0",
+        "audit-ci": "^7.1.0",
         "buffer": "^6.0.3",
         "eslint": "^10.1.0",
         "eslint-config-prettier": "^10.1.8",
@@ -2170,19 +2171,6 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
       "version": "8.58.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.0.tgz",
@@ -2436,6 +2424,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/antd": {
       "version": "6.3.5",
       "resolved": "https://registry.npmjs.org/antd/-/antd-6.3.5.tgz",
@@ -2519,6 +2523,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/audit-ci": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/audit-ci/-/audit-ci-7.1.0.tgz",
+      "integrity": "sha512-PjjEejlST57S/aDbeWLic0glJ8CNl/ekY3kfGFPMrPkmuaYaDKcMH0F9x9yS9Vp6URhuefSCubl/G0Y2r6oP0g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "escape-string-regexp": "^4.0.0",
+        "event-stream": "4.0.1",
+        "jju": "^1.4.0",
+        "jsonstream-next": "^3.0.0",
+        "readline-transform": "1.0.0",
+        "semver": "^7.0.0",
+        "tslib": "^2.0.0",
+        "yargs": "^17.0.0"
+      },
+      "bin": {
+        "audit-ci": "dist/bin.js"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/balanced-match": {
@@ -2658,6 +2686,21 @@
         "chart.js": ">=3.2.0"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2667,6 +2710,26 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/compute-scroll-into-view": {
       "version": "3.1.1",
@@ -2827,6 +2890,20 @@
         "@types/trusted-types": "^2.0.7"
       }
     },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -2846,6 +2923,16 @@
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -3062,6 +3149,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.1",
+        "from": "^0.1.7",
+        "map-stream": "0.0.7",
+        "pause-stream": "^0.0.11",
+        "split": "^1.0.1",
+        "stream-combiner": "^0.2.2",
+        "through": "^2.3.8"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -3159,6 +3262,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -3172,6 +3282,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/glob-parent": {
@@ -3270,6 +3390,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3278,6 +3405,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -3313,6 +3450,13 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -3435,6 +3579,33 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/jsonstream-next": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonstream-next/-/jsonstream-next-3.0.0.tgz",
+      "integrity": "sha512-aAi6oPhdt7BKyQn1SrIIGZBt0ukKuOUE1qV6kJ3GgioSOYzsRc8z9Hfr1BVmacA/jLe9nARfmgMGgn68BqIAgg==",
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "jsonparse": "^1.2.0",
+        "through2": "^4.0.2"
+      },
+      "bin": {
+        "jsonstream-next": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/keyv": {
@@ -3758,6 +3929,13 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/map-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+      "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/marked": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
@@ -3958,6 +4136,19 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "dev": true,
+      "license": [
+        "MIT",
+        "Apache2"
+      ],
+      "dependencies": {
+        "through": "~2.3"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4193,6 +4384,31 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readline-transform": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/readline-transform/-/readline-transform-1.0.0.tgz",
+      "integrity": "sha512-7KA6+N9IGat52d83dvxnApAWN+MtVb1MiVuMR/cf1O4kYsJG+g/Aav0AHcHKsb6StinayfPLne0+fMX2sOzAKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -4219,6 +4435,16 @@
       },
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/require-from-string": {
@@ -4271,6 +4497,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -4298,6 +4545,19 @@
       "license": "MIT",
       "dependencies": {
         "compute-scroll-into-view": "^3.0.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/set-cookie-parser": {
@@ -4362,6 +4622,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -4382,12 +4655,61 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stream-combiner": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "~0.1.1",
+        "through": "~2.3.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-convert": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
       "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
@@ -4424,6 +4746,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.22"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "3"
       }
     },
     "node_modules/tinybench": {
@@ -4575,8 +4914,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4655,6 +4993,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "8.0.16",
@@ -4963,6 +5308,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/ws": {
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
@@ -5001,6 +5364,45 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/browser": "^4.1.2",
     "antd": "^6.0.0",
+    "audit-ci": "^7.1.0",
     "buffer": "^6.0.3",
     "eslint": "^10.1.0",
     "eslint-config-prettier": "^10.1.8",
@@ -45,7 +46,7 @@
     "fmt": "prettier --write .",
     "fmt:check": "prettier --check .",
     "typecheck": "tsc --noEmit",
-    "audit:ci": "npm audit --audit-level=high",
+    "audit:ci": "audit-ci --config ./audit-ci.json",
     "e2e": "playwright test",
     "e2e:headed": "playwright test --headed --project=chromium",
     "e2e:headed:debug": "playwright test --headed --project=chromium --debug"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.0.0",
-    "reduct-js": "^1.20.0",
+    "reduct-js": "^1.21.0-beta.0",
     "typescript": "^6.0.0",
     "typescript-eslint": "^8.58.0",
     "vite": "^8.0.5",

--- a/src/Components/Replication/ReplicationSettingsForm.test.tsx
+++ b/src/Components/Replication/ReplicationSettingsForm.test.tsx
@@ -28,10 +28,10 @@ describe("Replication::ReplicationSettingsForm", () => {
       src_bucket: "Bucket1",
       dst_bucket: "destinationBucket",
       dst_host: "destinationHost",
-      dst_token: null,
+      dst_token: "destinationToken",
       dst_prefix: "robot-1/camera",
       entries: ["entry1", "entry2"],
-    } as any);
+    });
 
     const mockDiagnostics = Diagnostics.parse({
       hourly: {
@@ -132,36 +132,6 @@ describe("Replication::ReplicationSettingsForm", () => {
       "#replicationForm_dstHost",
     ) as HTMLInputElement;
     expect(input.value).toEqual("destinationHost");
-  });
-
-  it("omits a masked destination token from initial form values", async () => {
-    cleanup();
-    const formValues = React.createRef<ReplicationSettingsForm>();
-
-    const { container: tokenContainer } = render(
-      <MemoryRouter>
-        <ReplicationSettingsForm
-          ref={formValues}
-          client={client}
-          onCreated={() => null}
-          sourceBuckets={["Bucket1", "Bucket2"]}
-          replicationName={"TestReplication"}
-          readOnly={false}
-        />
-      </MemoryRouter>,
-    );
-
-    await waitFor(() =>
-      expect(tokenContainer.querySelector("form")).toBeTruthy(),
-    );
-    expect(formValues.current?.getInitialFormValues().dstToken).toBeUndefined();
-    expect(
-      (
-        tokenContainer.querySelector(
-          "#replicationForm_dstToken",
-        ) as HTMLInputElement
-      ).placeholder,
-    ).toEqual("Enter a token to replace the configured token");
   });
 
   it("shows the destination prefix if it is provided", async () => {

--- a/src/Components/Replication/ReplicationSettingsForm.test.tsx
+++ b/src/Components/Replication/ReplicationSettingsForm.test.tsx
@@ -28,10 +28,10 @@ describe("Replication::ReplicationSettingsForm", () => {
       src_bucket: "Bucket1",
       dst_bucket: "destinationBucket",
       dst_host: "destinationHost",
-      dst_token: "destinationToken",
+      dst_token: null,
       dst_prefix: "robot-1/camera",
       entries: ["entry1", "entry2"],
-    });
+    } as any);
 
     const mockDiagnostics = Diagnostics.parse({
       hourly: {
@@ -132,6 +132,36 @@ describe("Replication::ReplicationSettingsForm", () => {
       "#replicationForm_dstHost",
     ) as HTMLInputElement;
     expect(input.value).toEqual("destinationHost");
+  });
+
+  it("omits a masked destination token from initial form values", async () => {
+    cleanup();
+    const formValues = React.createRef<ReplicationSettingsForm>();
+
+    const { container: tokenContainer } = render(
+      <MemoryRouter>
+        <ReplicationSettingsForm
+          ref={formValues}
+          client={client}
+          onCreated={() => null}
+          sourceBuckets={["Bucket1", "Bucket2"]}
+          replicationName={"TestReplication"}
+          readOnly={false}
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() =>
+      expect(tokenContainer.querySelector("form")).toBeTruthy(),
+    );
+    expect(formValues.current?.getInitialFormValues().dstToken).toBeUndefined();
+    expect(
+      (
+        tokenContainer.querySelector(
+          "#replicationForm_dstToken",
+        ) as HTMLInputElement
+      ).placeholder,
+    ).toEqual("Enter a token to replace the configured token");
   });
 
   it("shows the destination prefix if it is provided", async () => {

--- a/src/Components/Replication/ReplicationSettingsForm.test.tsx
+++ b/src/Components/Replication/ReplicationSettingsForm.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, waitFor } from "@testing-library/react";
+import { cleanup, render, waitFor } from "@testing-library/react";
 import { act } from "react";
 import { MemoryRouter } from "react-router-dom";
 
@@ -29,6 +29,7 @@ describe("Replication::ReplicationSettingsForm", () => {
       dst_bucket: "destinationBucket",
       dst_host: "destinationHost",
       dst_token: "destinationToken",
+      dst_prefix: "robot-1/camera",
       entries: ["entry1", "entry2"],
     });
 
@@ -86,6 +87,7 @@ describe("Replication::ReplicationSettingsForm", () => {
     expect(container.querySelector("#replicationForm_dstBucket")).toBeTruthy();
     expect(container.querySelector("#replicationForm_dstHost")).toBeTruthy();
     expect(container.querySelector("#replicationForm_dstToken")).toBeTruthy();
+    expect(container.querySelector("#replicationForm_dstPrefix")).toBeTruthy();
     expect(container.querySelector("#replicationForm_entries")).toBeTruthy();
   });
 
@@ -132,6 +134,18 @@ describe("Replication::ReplicationSettingsForm", () => {
     expect(input.value).toEqual("destinationHost");
   });
 
+  it("shows the destination prefix if it is provided", async () => {
+    await waitFor(() =>
+      expect(
+        container.querySelector("#replicationForm_dstPrefix"),
+      ).toBeTruthy(),
+    );
+    const input = container.querySelector(
+      "#replicationForm_dstPrefix",
+    ) as HTMLInputElement;
+    expect(input.value).toEqual("robot-1/camera");
+  });
+
   it("shows the selected entries if they are provided", async () => {
     await waitFor(() =>
       expect(container.querySelector("#replicationForm_entries")).toBeTruthy(),
@@ -148,6 +162,7 @@ describe("Replication::ReplicationSettingsForm", () => {
   });
 
   it("disables record settings inputs and radios in read-only mode", async () => {
+    cleanup();
     const { container: readOnlyContainer } = render(
       <MemoryRouter>
         <ReplicationSettingsForm
@@ -162,7 +177,9 @@ describe("Replication::ReplicationSettingsForm", () => {
 
     // Wait for the component to finish rendering
     await waitFor(() =>
-      expect(readOnlyContainer.querySelector("form")).toBeTruthy(),
+      expect(
+        readOnlyContainer.querySelector("#replicationForm_dstPrefix"),
+      ).toBeTruthy(),
     );
 
     // Check that each Radio.Group is disabled
@@ -189,6 +206,11 @@ describe("Replication::ReplicationSettingsForm", () => {
     );
     expect(updateButton).toBeTruthy();
     expect((updateButton as HTMLButtonElement).disabled).toBe(true);
+
+    const prefixInput = readOnlyContainer.querySelector(
+      "#replicationForm_dstPrefix",
+    ) as HTMLInputElement;
+    expect(prefixInput.disabled).toBe(true);
   });
 
   it("verifies Monaco editor is non-editable in read-only mode", async () => {
@@ -286,6 +308,7 @@ describe("Replication::ReplicationSettingsForm", () => {
       dstBucket: "destinationBucket",
       dstHost: "destinationHost",
       dstToken: "destinationToken",
+      dstPrefix: "robot-1/camera",
       eachN: 10n,
       eachS: 0.5,
       entries: ["entry1", "entry2"],
@@ -301,6 +324,7 @@ describe("Replication::ReplicationSettingsForm", () => {
       dstBucket: "destinationBucket",
       dstHost: "destinationHost",
       dstToken: "destinationToken",
+      dstPrefix: "robot-1/camera",
       entries: ["entry1", "entry2"],
       eachN: 10n,
       eachS: 0.5,
@@ -373,6 +397,34 @@ describe("Replication::ReplicationSettingsForm", () => {
         "TestReplication",
         expected_settings,
       );
+    });
+
+    it("submits an omitted destination prefix unchanged", async () => {
+      const ref = React.createRef<ReplicationSettingsForm>();
+
+      render(
+        <MemoryRouter>
+          <ReplicationSettingsForm
+            ref={ref}
+            client={client}
+            onCreated={() => null}
+            sourceBuckets={["Bucket1", "Bucket2"]}
+            readOnly={false}
+          />
+        </MemoryRouter>,
+      );
+
+      const component = ref.current!;
+      const settingsWithoutPrefix = { ...form_settings, dstPrefix: undefined };
+
+      await act(async () => {
+        await component.onFinish(settingsWithoutPrefix as any);
+      });
+
+      expect(client.createReplication).toBeCalledWith("NewReplication", {
+        ...expected_settings,
+        dstPrefix: undefined,
+      });
     });
   });
 });

--- a/src/Components/Replication/ReplicationSettingsForm.tsx
+++ b/src/Components/Replication/ReplicationSettingsForm.tsx
@@ -46,7 +46,7 @@ interface FormValues {
   srcBucket: string;
   dstBucket: string;
   dstHost: string;
-  dstToken: string;
+  dstToken?: string;
   dstPrefix?: string;
   entries: string[];
   recordSettings: Array<{
@@ -254,7 +254,8 @@ export default class ReplicationSettingsForm extends React.Component<
       srcBucket: settings.srcBucket,
       dstBucket: settings.dstBucket,
       dstHost: settings.dstHost,
-      dstToken: settings.dstToken,
+      // ReductStore masks a configured destination token as null on reads.
+      dstToken: settings.dstToken ?? undefined,
       dstPrefix: settings.dstPrefix,
       entries: settings.entries || entries,
       recordSettings,
@@ -442,7 +443,14 @@ export default class ReplicationSettingsForm extends React.Component<
                 }
                 name="dstToken"
               >
-                <Input disabled={readOnly} />
+                <Input
+                  disabled={readOnly}
+                  placeholder={
+                    this.state.settings?.dstToken === null
+                      ? "Enter a token to replace the configured token"
+                      : undefined
+                  }
+                />
               </Form.Item>
             </Col>
           </Row>

--- a/src/Components/Replication/ReplicationSettingsForm.tsx
+++ b/src/Components/Replication/ReplicationSettingsForm.tsx
@@ -46,7 +46,7 @@ interface FormValues {
   srcBucket: string;
   dstBucket: string;
   dstHost: string;
-  dstToken?: string;
+  dstToken: string;
   dstPrefix?: string;
   entries: string[];
   recordSettings: Array<{
@@ -254,8 +254,7 @@ export default class ReplicationSettingsForm extends React.Component<
       srcBucket: settings.srcBucket,
       dstBucket: settings.dstBucket,
       dstHost: settings.dstHost,
-      // ReductStore masks a configured destination token as null on reads.
-      dstToken: settings.dstToken ?? undefined,
+      dstToken: settings.dstToken,
       dstPrefix: settings.dstPrefix,
       entries: settings.entries || entries,
       recordSettings,
@@ -443,14 +442,7 @@ export default class ReplicationSettingsForm extends React.Component<
                 }
                 name="dstToken"
               >
-                <Input
-                  disabled={readOnly}
-                  placeholder={
-                    this.state.settings?.dstToken === null
-                      ? "Enter a token to replace the configured token"
-                      : undefined
-                  }
-                />
+                <Input disabled={readOnly} />
               </Form.Item>
             </Col>
           </Row>

--- a/src/Components/Replication/ReplicationSettingsForm.tsx
+++ b/src/Components/Replication/ReplicationSettingsForm.tsx
@@ -47,6 +47,7 @@ interface FormValues {
   dstBucket: string;
   dstHost: string;
   dstToken: string;
+  dstPrefix?: string;
   entries: string[];
   recordSettings: Array<{
     action: FilterType;
@@ -83,8 +84,16 @@ export default class ReplicationSettingsForm extends React.Component<
    */
   onFinish = async (values: FormValues) => {
     const { replicationName, client, onCreated } = this.props;
-    const { srcBucket, dstBucket, dstHost, dstToken, entries, eachN, eachS } =
-      values;
+    const {
+      srcBucket,
+      dstBucket,
+      dstHost,
+      dstToken,
+      dstPrefix,
+      entries,
+      eachN,
+      eachS,
+    } = values;
     const include: Record<string, string> = {};
     const exclude: Record<string, string> = {};
     if (values.recordSettings) {
@@ -113,6 +122,7 @@ export default class ReplicationSettingsForm extends React.Component<
         dstBucket,
         dstHost,
         dstToken,
+        dstPrefix,
         entries,
         include,
         exclude,
@@ -245,6 +255,7 @@ export default class ReplicationSettingsForm extends React.Component<
       dstBucket: settings.dstBucket,
       dstHost: settings.dstHost,
       dstToken: settings.dstToken,
+      dstPrefix: settings.dstPrefix,
       entries: settings.entries || entries,
       recordSettings,
       when: formattedWhen,
@@ -399,6 +410,21 @@ export default class ReplicationSettingsForm extends React.Component<
                     message: "Please input the destination host URL.",
                   },
                 ]}
+                className="ReplicationField"
+              >
+                <Input disabled={readOnly} />
+              </Form.Item>
+
+              <Form.Item
+                label={
+                  <span>
+                    Prefix&nbsp;
+                    <Tooltip title="Prepended only to destination entry names, for example robot-1/camera/front.">
+                      <InfoCircleOutlined />
+                    </Tooltip>
+                  </span>
+                }
+                name="dstPrefix"
                 className="ReplicationField"
               >
                 <Input disabled={readOnly} />

--- a/src/Components/Replication/ReplicationSettingsForm.tsx
+++ b/src/Components/Replication/ReplicationSettingsForm.tsx
@@ -394,6 +394,22 @@ export default class ReplicationSettingsForm extends React.Component<
               >
                 <Input disabled={readOnly} />
               </Form.Item>
+
+              <Form.Item
+                label={
+                  <span>
+                    Prefix&nbsp;
+                    <Tooltip title="Prepended only to destination entry names, for example robot-1/camera/front.">
+                      <InfoCircleOutlined />
+                    </Tooltip>
+                  </span>
+                }
+                name="dstPrefix"
+                className="ReplicationField"
+              >
+                <Input disabled={readOnly} />
+              </Form.Item>
+
               <Form.Item
                 label={
                   <span>
@@ -410,21 +426,6 @@ export default class ReplicationSettingsForm extends React.Component<
                     message: "Please input the destination host URL.",
                   },
                 ]}
-                className="ReplicationField"
-              >
-                <Input disabled={readOnly} />
-              </Form.Item>
-
-              <Form.Item
-                label={
-                  <span>
-                    Prefix&nbsp;
-                    <Tooltip title="Prepended only to destination entry names, for example robot-1/camera/front.">
-                      <InfoCircleOutlined />
-                    </Tooltip>
-                  </span>
-                }
-                name="dstPrefix"
                 className="ReplicationField"
               >
                 <Input disabled={readOnly} />

--- a/src/Components/Replication/ReplicationSettingsForm.tsx
+++ b/src/Components/Replication/ReplicationSettingsForm.tsx
@@ -399,7 +399,7 @@ export default class ReplicationSettingsForm extends React.Component<
                 label={
                   <span>
                     Prefix&nbsp;
-                    <Tooltip title="Prepended only to destination entry names, for example robot-1/camera/front.">
+                    <Tooltip title="Prepended to destination entry names.">
                       <InfoCircleOutlined />
                     </Tooltip>
                   </span>


### PR DESCRIPTION
Closes #218

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

- Added an optional destination prefix field to replication create, edit, and read-only settings forms.
- Preserve `dstPrefix` when loading and submitting replication settings.
- Updated `reduct-js` to `1.21.0-beta.0` so the SDK parses and serializes `dst_prefix`.
- Added coverage for configured, omitted, and read-only destination prefixes.

### Related issues

https://github.com/reductstore/web-console/issues/218

### Does this PR introduce a breaking change?

No.

### Other information:

Validated with:

- `npm run test:ci -- src/Components/Replication/ReplicationSettingsForm.test.tsx`
- `npm run typecheck`
- `npm run fmt:check`
- `git diff --check`

`npm run test:ci` remains blocked by unrelated test discovery in `.kilo/node_modules` and existing BucketDetail/EntryDetail UI test timeouts.
