### PR TITLE
Add replication compression setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,9 @@ yarn-error.log*
 /test-results/
 /playwright-report/
 /blob-report/
+
+# Kilo project skills are shared configuration.
+!.kilo/
+.kilo/*
+!.kilo/skills/
+!.kilo/skills/**

--- a/.kilo/skills/create-pr/SKILL.md
+++ b/.kilo/skills/create-pr/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: create-pr
+description: Create GitHub pull requests with the gh CLI using the reductstore/.github PR template, then update CHANGELOG.md with the created PR ID and commit the changelog (do not push). Use when a user asks to open a PR and record its ID in the changelog.
+---
+
+# Create Pr
+
+## Overview
+
+Create a PR using the standardized template from reductstore/.github, then record the PR number in CHANGELOG.md and commit the changelog without pushing.
+
+## Workflow
+
+### 1) Preconditions
+
+- Ensure `gh auth status` is logged in and the current branch is the intended PR branch.
+- Ensure the working tree is clean (or only the intended changes are present).
+- Use context from the current conversation to infer intent, scope, and any constraints.
+
+### 2) Understand changes and rationale
+
+- Compare the current branch against `main` to understand what changed and why (use this to derive the PR title, description, and rationale):
+  - `git fetch origin main`
+  - `git log --oneline origin/main..HEAD`
+  - `git diff --stat origin/main...HEAD`
+  - `git diff origin/main...HEAD`
+- If the branch name starts with an issue number (e.g., `123-...`), use that issue in the rationale and fill the `Closes #` line in the PR template.
+- If the branch name does not include an issue number, infer the likely issue from changes and conversation context, or leave `Closes #` empty if unsure.
+
+### 3) Fetch the PR template
+
+Use the helper script to download the latest PR template from reductstore/.github:
+
+```bash
+./.kilo/skills/create-pr/scripts/fetch_pr_template.sh /tmp/pr_template.md
+```
+
+Fill in the template file with the relevant summary, testing, and rationale derived from the diff and conversation context.
+
+### 4) Create the PR with gh
+
+Use the filled template as the PR body:
+
+```bash
+gh pr create --title "<title>" --body-file /tmp/pr_template.md
+```
+
+Capture the PR number after creation:
+
+```bash
+gh pr view --json number -q .number
+```
+
+### 5) Update CHANGELOG.md
+
+- Find the appropriate section (usually the most recent/unreleased section).
+- Add a new entry following the existing style in the file.
+- Include the PR ID as `#<number>` exactly as prior entries do.
+
+### 6) Commit (no push)
+
+Stage and commit the changelog update only:
+
+```bash
+git add CHANGELOG.md
+git commit -m "Update changelog for PR #<number>"
+```
+
+Do not push.
+
+## Resources
+
+### scripts/
+
+- `fetch_pr_template.sh`: Download the latest PR template from reductstore/.github.

--- a/.kilo/skills/create-pr/scripts/fetch_pr_template.sh
+++ b/.kilo/skills/create-pr/scripts/fetch_pr_template.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <output-file>" >&2
+  exit 1
+fi
+
+output_file="$1"
+
+curl -sS -L \
+  "https://raw.githubusercontent.com/reductstore/.github/main/.github/pull_request_template.md" \
+  -o "$output_file"
+
+if [[ ! -s "$output_file" ]]; then
+  echo "Template download failed or empty: $output_file" >&2
+  exit 1
+fi
+
+echo "Template saved to $output_file"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support destination entry prefixes for replications, [PR-225](https://github.com/reductstore/web-console/pull/225)
-- Support wire compression settings for replications, [#220](https://github.com/reductstore/web-console/issues/220)
+- Support wire compression settings for replications, [PR-226](https://github.com/reductstore/web-console/pull/226)
 
 ## 1.15.1 - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support destination entry prefixes for replications, [PR-225](https://github.com/reductstore/web-console/pull/225)
+- Support wire compression settings for replications, [#220](https://github.com/reductstore/web-console/issues/220)
 
 ## 1.15.1 - 2026-06-19
 

--- a/src/Components/Replication/ReplicationSettingsForm.test.tsx
+++ b/src/Components/Replication/ReplicationSettingsForm.test.tsx
@@ -3,7 +3,12 @@ import { cleanup, render, waitFor } from "@testing-library/react";
 import { act } from "react";
 import { MemoryRouter } from "react-router-dom";
 
-import { Client, ReplicationInfo, ReplicationSettings } from "reduct-js";
+import {
+  Client,
+  ReplicationCompression,
+  ReplicationInfo,
+  ReplicationSettings,
+} from "reduct-js";
 import { mockJSDOM } from "../../Helpers/TestHelpers";
 import ReplicationSettingsForm from "./ReplicationSettingsForm";
 import { Diagnostics } from "reduct-js/lib/cjs/messages/Diagnostics";
@@ -30,6 +35,7 @@ describe("Replication::ReplicationSettingsForm", () => {
       dst_host: "destinationHost",
       dst_token: "destinationToken",
       dst_prefix: "robot-1/camera",
+      compression: ReplicationCompression.ZSTD,
       entries: ["entry1", "entry2"],
     });
 
@@ -88,6 +94,9 @@ describe("Replication::ReplicationSettingsForm", () => {
     expect(container.querySelector("#replicationForm_dstHost")).toBeTruthy();
     expect(container.querySelector("#replicationForm_dstToken")).toBeTruthy();
     expect(container.querySelector("#replicationForm_dstPrefix")).toBeTruthy();
+    expect(
+      container.querySelector("#replicationForm_compression"),
+    ).toBeTruthy();
     expect(container.querySelector("#replicationForm_entries")).toBeTruthy();
   });
 
@@ -144,6 +153,49 @@ describe("Replication::ReplicationSettingsForm", () => {
       "#replicationForm_dstPrefix",
     ) as HTMLInputElement;
     expect(input.value).toEqual("robot-1/camera");
+  });
+
+  it("shows configured compression", () => {
+    const selectContent = container
+      .querySelector("#replicationForm_compression")
+      ?.closest(".ant-select")
+      ?.querySelector(".ant-select-content");
+    expect(selectContent?.textContent).toContain("Zstandard (zstd)");
+  });
+
+  it("defaults missing compression to none", async () => {
+    cleanup();
+    client.getReplication = vi.fn().mockResolvedValue({
+      settings: ReplicationSettings.parse({
+        src_bucket: "Bucket1",
+        dst_bucket: "destinationBucket",
+        dst_host: "destinationHost",
+        dst_token: "destinationToken",
+        entries: ["entry1", "entry2"],
+      }),
+    });
+
+    const { container: legacyContainer } = render(
+      <MemoryRouter>
+        <ReplicationSettingsForm
+          client={client}
+          onCreated={() => null}
+          sourceBuckets={["Bucket1", "Bucket2"]}
+          replicationName="TestReplication"
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() =>
+      expect(
+        legacyContainer.querySelector("#replicationForm_compression"),
+      ).toBeTruthy(),
+    );
+    const selectContent = legacyContainer
+      .querySelector("#replicationForm_compression")
+      ?.closest(".ant-select")
+      ?.querySelector(".ant-select-content");
+    expect(selectContent?.textContent).toContain("None");
   });
 
   it("shows the selected entries if they are provided", async () => {
@@ -211,6 +263,11 @@ describe("Replication::ReplicationSettingsForm", () => {
       "#replicationForm_dstPrefix",
     ) as HTMLInputElement;
     expect(prefixInput.disabled).toBe(true);
+
+    const compressionSelect = readOnlyContainer
+      .querySelector("#replicationForm_compression")
+      ?.closest(".ant-select");
+    expect(compressionSelect?.classList).toContain("ant-select-disabled");
   });
 
   it("verifies Monaco editor is non-editable in read-only mode", async () => {
@@ -309,6 +366,7 @@ describe("Replication::ReplicationSettingsForm", () => {
       dstHost: "destinationHost",
       dstToken: "destinationToken",
       dstPrefix: "robot-1/camera",
+      compression: ReplicationCompression.GZIP,
       eachN: 10n,
       eachS: 0.5,
       entries: ["entry1", "entry2"],
@@ -325,6 +383,7 @@ describe("Replication::ReplicationSettingsForm", () => {
       dstHost: "destinationHost",
       dstToken: "destinationToken",
       dstPrefix: "robot-1/camera",
+      compression: ReplicationCompression.GZIP,
       entries: ["entry1", "entry2"],
       eachN: 10n,
       eachS: 0.5,
@@ -424,6 +483,34 @@ describe("Replication::ReplicationSettingsForm", () => {
       expect(client.createReplication).toBeCalledWith("NewReplication", {
         ...expected_settings,
         dstPrefix: undefined,
+      });
+    });
+
+    it("submits omitted compression as none", async () => {
+      const ref = React.createRef<ReplicationSettingsForm>();
+
+      render(
+        <MemoryRouter>
+          <ReplicationSettingsForm
+            ref={ref}
+            client={client}
+            onCreated={() => null}
+            sourceBuckets={["Bucket1", "Bucket2"]}
+            readOnly={false}
+          />
+        </MemoryRouter>,
+      );
+
+      await act(async () => {
+        await ref.current!.onFinish({
+          ...form_settings,
+          compression: undefined,
+        } as any);
+      });
+
+      expect(client.createReplication).toBeCalledWith("NewReplication", {
+        ...expected_settings,
+        compression: ReplicationCompression.NONE,
       });
     });
   });

--- a/src/Components/Replication/ReplicationSettingsForm.tsx
+++ b/src/Components/Replication/ReplicationSettingsForm.tsx
@@ -1,5 +1,10 @@
 import React from "react";
-import { APIError, Client, FullReplicationInfo } from "reduct-js"; // Adjust import paths as necessary
+import {
+  APIError,
+  Client,
+  FullReplicationInfo,
+  ReplicationCompression,
+} from "reduct-js"; // Adjust import paths as necessary
 import {
   Button,
   Col,
@@ -48,6 +53,7 @@ interface FormValues {
   dstHost: string;
   dstToken: string;
   dstPrefix?: string;
+  compression?: ReplicationCompression;
   entries: string[];
   recordSettings: Array<{
     action: FilterType;
@@ -90,6 +96,7 @@ export default class ReplicationSettingsForm extends React.Component<
       dstHost,
       dstToken,
       dstPrefix,
+      compression,
       entries,
       eachN,
       eachS,
@@ -123,6 +130,7 @@ export default class ReplicationSettingsForm extends React.Component<
         dstHost,
         dstToken,
         dstPrefix,
+        compression: compression ?? ReplicationCompression.NONE,
         entries,
         include,
         exclude,
@@ -230,7 +238,7 @@ export default class ReplicationSettingsForm extends React.Component<
     const { replicationName: name } = this.props;
 
     if (!settings) {
-      return { name };
+      return { name, compression: ReplicationCompression.NONE };
     }
 
     const include = settings.include || {};
@@ -256,6 +264,7 @@ export default class ReplicationSettingsForm extends React.Component<
       dstHost: settings.dstHost,
       dstToken: settings.dstToken,
       dstPrefix: settings.dstPrefix,
+      compression: settings.compression ?? ReplicationCompression.NONE,
       entries: settings.entries || entries,
       recordSettings,
       when: formattedWhen,
@@ -368,6 +377,33 @@ export default class ReplicationSettingsForm extends React.Component<
                     value: entry,
                     label: entry,
                   }))}
+                />
+              </Form.Item>
+              <Form.Item
+                label={
+                  <span>
+                    Compression&nbsp;
+                    <Tooltip title="Compress replication data while it is sent to the destination.">
+                      <InfoCircleOutlined />
+                    </Tooltip>
+                  </span>
+                }
+                name="compression"
+                className="ReplicationField"
+              >
+                <Select
+                  disabled={readOnly}
+                  options={[
+                    { value: ReplicationCompression.NONE, label: "None" },
+                    {
+                      value: ReplicationCompression.ZSTD,
+                      label: "Zstandard (zstd)",
+                    },
+                    {
+                      value: ReplicationCompression.GZIP,
+                      label: "Gzip (gzip)",
+                    },
+                  ]}
                 />
               </Form.Item>
             </Col>


### PR DESCRIPTION
Closes #220

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature.

### What was changed?

- Add `none`, `zstd`, and `gzip` wire-compression settings to the shared replication settings form, including read-only mode.
- Default new, legacy, and omitted compression values to `none` in replication payloads.
- Add component coverage for configured, legacy, read-only, and submitted compression values.
- Export the repository `create-pr` skill from `.codex` to the canonical `.kilo/skills` path.

### Related issues

- https://github.com/reductstore/web-console/issues/220

### Does this PR introduce a breaking change?

No.

### Other information:

`npm run fmt`, `npm run typecheck`, and `npx vitest run src/Components/Replication/ReplicationSettingsForm.test.tsx` pass. The full `npm run test:ci` suite is currently blocked by unrelated `.kilo/node_modules` Zod test discovery errors and existing test timeouts.
