### PR TITLE
Support lifecycle processing intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support destination entry prefixes for replications, [PR-225](https://github.com/reductstore/web-console/pull/225)
 - Support wire compression settings for replications, [PR-226](https://github.com/reductstore/web-console/pull/226)
+- Support lifecycle processing intervals, [#224](https://github.com/reductstore/web-console/issues/224)
 
 ## 1.15.1 - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support destination entry prefixes for replications, [PR-225](https://github.com/reductstore/web-console/pull/225)
 - Support wire compression settings for replications, [PR-226](https://github.com/reductstore/web-console/pull/226)
-- Support lifecycle processing intervals, [#224](https://github.com/reductstore/web-console/issues/224)
+- Support lifecycle processing intervals, [PR-227](https://github.com/reductstore/web-console/pull/227)
 
 ## 1.15.1 - 2026-06-19
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.0.0",
-        "reduct-js": "^1.21.0-beta.0",
+        "reduct-js": "^1.21.0-beta.1",
         "typescript": "^6.0.0",
         "typescript-eslint": "^8.58.0",
         "vite": "^8.0.5",
@@ -4424,9 +4424,9 @@
       }
     },
     "node_modules/reduct-js": {
-      "version": "1.21.0-beta.0",
-      "resolved": "https://registry.npmjs.org/reduct-js/-/reduct-js-1.21.0-beta.0.tgz",
-      "integrity": "sha512-D1ssIRG0uZNyyA4XK9dbMpJhdBKg3YBlZXaYmT20Clt9KiyBQn2X3/NWlU3wVl9jzV0UXDY3E2V3kfDRu53dRw==",
+      "version": "1.21.0-beta.1",
+      "resolved": "https://registry.npmjs.org/reduct-js/-/reduct-js-1.21.0-beta.1.tgz",
+      "integrity": "sha512-Uhff6KB/KTfP6N4jGpn24Fd6LVzLSI01YghnTnft2vLgcpeuDj+wBjWlquLReJIFbA041S60i+zItXi+oGbAbg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.0.0",
-    "reduct-js": "^1.21.0-beta.0",
+    "reduct-js": "^1.21.0-beta.1",
     "typescript": "^6.0.0",
     "typescript-eslint": "^8.58.0",
     "vite": "^8.0.5",

--- a/src/Components/Lifecycle/LifecycleSettingsForm.test.tsx
+++ b/src/Components/Lifecycle/LifecycleSettingsForm.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, waitFor } from "@testing-library/react";
+import { cleanup, render, waitFor } from "@testing-library/react";
 import { act } from "react";
 import { MemoryRouter } from "react-router-dom";
 
@@ -34,6 +34,7 @@ describe("Lifecycle::LifecycleSettingsForm", () => {
       entries: ["entry1", "entry2"],
       older_than: "1h",
       interval: "10m",
+      processing_interval: "12h",
       when: {},
       mode: "enabled",
     });
@@ -72,6 +73,46 @@ describe("Lifecycle::LifecycleSettingsForm", () => {
     expect(container.querySelector("#lifecycleForm_name")).toBeTruthy();
     expect(container.querySelector("#lifecycleForm_bucket")).toBeTruthy();
     expect(container.querySelector("#lifecycleForm_olderThan")).toBeTruthy();
+    expect(
+      container.querySelector("#lifecycleForm_processingInterval"),
+    ).toBeTruthy();
+  });
+
+  it("shows the loaded processing interval", () => {
+    const input = container.querySelector(
+      "#lifecycleForm_processingInterval",
+    ) as HTMLInputElement;
+    expect(input.value).toEqual("12h");
+  });
+
+  it("disables the processing interval in read-only mode", async () => {
+    cleanup();
+
+    const { container: readOnlyContainer } = render(
+      <MemoryRouter>
+        <LifecycleSettingsForm
+          client={client}
+          onCreated={() => null}
+          sourceBuckets={["Bucket1", "Bucket2"]}
+          lifecycleName="test-lifecycle"
+          readOnly
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() =>
+      expect(
+        readOnlyContainer.querySelector("#lifecycleForm_processingInterval"),
+      ).toBeTruthy(),
+    );
+
+    expect(
+      (
+        readOnlyContainer.querySelector(
+          "#lifecycleForm_processingInterval",
+        ) as HTMLInputElement
+      ).disabled,
+    ).toBeTruthy();
   });
 
   it("shows lifecycle name and disables it for update mode", () => {
@@ -113,6 +154,7 @@ describe("Lifecycle::LifecycleSettingsForm", () => {
         bucket: "Bucket1",
         olderThan: "1h",
         interval: "10m",
+        processingInterval: "6h",
         entries: ["entry1"],
       });
     });
@@ -126,6 +168,7 @@ describe("Lifecycle::LifecycleSettingsForm", () => {
         bucket: "Bucket1",
         olderThan: "1h",
         interval: "10m",
+        processingInterval: "6h",
         entries: ["entry1"],
       }),
     );
@@ -152,6 +195,7 @@ describe("Lifecycle::LifecycleSettingsForm", () => {
         lifecycleType: "delete",
         bucket: "Bucket1",
         olderThan: "1h",
+        processingInterval: undefined,
         entries: [],
         dryRun: true,
       });
@@ -160,6 +204,37 @@ describe("Lifecycle::LifecycleSettingsForm", () => {
     expect(client.createLifecycle).toHaveBeenCalledWith(
       "new-lifecycle",
       expect.objectContaining({ mode: LifecycleMode.DRY_RUN }),
+    );
+  });
+
+  it("omits processing interval when it is not provided", async () => {
+    const ref = React.createRef<LifecycleSettingsForm>();
+
+    render(
+      <MemoryRouter>
+        <LifecycleSettingsForm
+          ref={ref}
+          client={client}
+          onCreated={() => null}
+          sourceBuckets={["Bucket1", "Bucket2"]}
+          readOnly={false}
+        />
+      </MemoryRouter>,
+    );
+
+    await act(async () => {
+      await ref.current!.onFinish({
+        name: "new-lifecycle",
+        lifecycleType: "delete",
+        bucket: "Bucket1",
+        olderThan: "1h",
+        entries: [],
+      });
+    });
+
+    expect(client.createLifecycle).toHaveBeenCalledWith(
+      "new-lifecycle",
+      expect.objectContaining({ processingInterval: undefined }),
     );
   });
 
@@ -193,6 +268,7 @@ describe("Lifecycle::LifecycleSettingsForm", () => {
         bucket: "Bucket2",
         olderThan: "2h",
         interval: "15m",
+        processingInterval: "1d",
         entries: ["entry2"],
       });
     });
@@ -206,6 +282,7 @@ describe("Lifecycle::LifecycleSettingsForm", () => {
         bucket: "Bucket2",
         olderThan: "2h",
         interval: "15m",
+        processingInterval: "1d",
         entries: ["entry2"],
       }),
     );

--- a/src/Components/Lifecycle/LifecycleSettingsForm.tsx
+++ b/src/Components/Lifecycle/LifecycleSettingsForm.tsx
@@ -53,6 +53,7 @@ interface FormValues {
   bucket: string;
   olderThan: string;
   interval?: string;
+  processingInterval?: string;
   entries: string[];
   dryRun?: boolean;
 }
@@ -106,6 +107,7 @@ export default class LifecycleSettingsForm extends React.Component<
         entries: values.entries || [],
         olderThan: values.olderThan,
         interval: values.interval || undefined,
+        processingInterval: values.processingInterval || undefined,
         when: supportsWhen ? (parsedWhen ?? {}) : undefined,
         mode,
       };
@@ -141,6 +143,7 @@ export default class LifecycleSettingsForm extends React.Component<
           bucket: settings.bucket,
           olderThan: settings.olderThan,
           interval: settings.interval,
+          processingInterval: settings.processingInterval,
           entries: settings.entries || [],
         };
 
@@ -228,6 +231,7 @@ export default class LifecycleSettingsForm extends React.Component<
       bucket: settings.bucket,
       olderThan: settings.olderThan,
       interval: settings.interval,
+      processingInterval: settings.processingInterval,
       entries: settings.entries || entries,
       when: formattedWhen,
     };
@@ -389,6 +393,21 @@ export default class LifecycleSettingsForm extends React.Component<
                       </span>
                     }
                     name="interval"
+                    className="LifecycleField"
+                  >
+                    <Input disabled={readOnly} />
+                  </Form.Item>
+
+                  <Form.Item
+                    label={
+                      <span>
+                        Processing Interval&nbsp;
+                        <Tooltip title="Limits the span of data time processed per run, e.g. 6h, 12h, or 1d. Defaults to 24 * interval when blank.">
+                          <InfoCircleOutlined />
+                        </Tooltip>
+                      </span>
+                    }
+                    name="processingInterval"
                     className="LifecycleField"
                   >
                     <Input disabled={readOnly} />

--- a/src/Views/Lifecycles/LifecycleDetail.test.tsx
+++ b/src/Views/Lifecycles/LifecycleDetail.test.tsx
@@ -40,6 +40,7 @@ describe("LifecycleDetail", () => {
       entries: ["entry1", "entry2"],
       older_than: "1h",
       interval: "10m",
+      processing_interval: "12h",
       when: {},
       mode: "enabled",
     });
@@ -80,6 +81,7 @@ describe("LifecycleDetail", () => {
     expect(screen.getByText("{}", { exact: false })).toBeTruthy();
     expect(screen.getByText("bucket1")).toBeTruthy();
     expect(screen.getByText("1h")).toBeTruthy();
+    expect(screen.getByText("12h")).toBeTruthy();
   });
 
   it("renders mode control and action buttons", async () => {

--- a/src/Views/Lifecycles/LifecycleDetail.tsx
+++ b/src/Views/Lifecycles/LifecycleDetail.tsx
@@ -334,6 +334,9 @@ export default function LifecycleDetail(props: Readonly<Props>) {
             <Descriptions.Item label="Interval">
               {lifecycle.settings.interval || "-"}
             </Descriptions.Item>
+            <Descriptions.Item label="Processing Interval">
+              {lifecycle.settings.processingInterval || "-"}
+            </Descriptions.Item>
             <Descriptions.Item label="Entries" span="filled">
               <Typography.Paragraph
                 style={{


### PR DESCRIPTION
Closes #224

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

Adds lifecycle `processing_interval` support to the create and update forms, and displays the configured value in lifecycle details. Updates `reduct-js` to a version that exposes the setting.

### Related issues

https://github.com/reductstore/web-console/issues/224

### Does this PR introduce a breaking change?

No.

### Other information:

The setting is optional and preserves the server default when left blank.
