### PR TITLE
Add query time range shift controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support destination entry prefixes for replications, [PR-225](https://github.com/reductstore/web-console/pull/225)
 - Support wire compression settings for replications, [PR-226](https://github.com/reductstore/web-console/pull/226)
 - Support lifecycle processing intervals, [PR-227](https://github.com/reductstore/web-console/pull/227)
-- Add previous and next controls for shifting query time ranges, [Issue-196](https://github.com/reductstore/web-console/issues/196)
+- Add previous and next controls for shifting query time ranges, [PR-228](https://github.com/reductstore/web-console/pull/228)
 
 ## 1.15.1 - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support destination entry prefixes for replications, [PR-225](https://github.com/reductstore/web-console/pull/225)
 - Support wire compression settings for replications, [PR-226](https://github.com/reductstore/web-console/pull/226)
 - Support lifecycle processing intervals, [PR-227](https://github.com/reductstore/web-console/pull/227)
+- Add previous and next controls for shifting query time ranges, [Issue-196](https://github.com/reductstore/web-console/issues/196)
 
 ## 1.15.1 - 2026-06-19
 

--- a/src/Components/Entry/TimeRangeDropdown.test.tsx
+++ b/src/Components/Entry/TimeRangeDropdown.test.tsx
@@ -18,7 +18,11 @@ describe("TimeRangeDropdown", () => {
 
   const openMenuAndClick = async (label: string) => {
     await act(async () => {
-      fireEvent.click(screen.getByRole("button"));
+      fireEvent.click(
+        screen
+          .getAllByRole("button")
+          .find((button) => !button.hasAttribute("aria-label"))!,
+      );
     });
     await act(async () => {
       fireEvent.click(screen.getByText(label));
@@ -27,7 +31,9 @@ describe("TimeRangeDropdown", () => {
 
   it("renders the dropdown button", () => {
     render(<TimeRangeDropdown onSelectRange={mockOnSelectRange} />);
-    expect(screen.getByRole("button").textContent).toContain("Custom range");
+    expect(
+      screen.getByRole("button", { name: /custom range/i }).textContent,
+    ).toContain("Custom range");
   });
 
   it("triggers onSelectRange for 'Last 1 hour'", async () => {
@@ -188,7 +194,9 @@ describe("TimeRangeDropdown", () => {
         currentRange={last7Range}
       />,
     );
-    expect(screen.getByRole("button").textContent).toContain("Last 7 days");
+    expect(
+      screen.getByRole("button", { name: /last 7 days/i }).textContent,
+    ).toContain("Last 7 days");
   });
 
   it("displays 'Custom range' for unmatched currentRange", () => {
@@ -202,6 +210,94 @@ describe("TimeRangeDropdown", () => {
         currentRange={customRange}
       />,
     );
-    expect(screen.getByRole("button").textContent).toContain("Custom range");
+    expect(
+      screen.getByRole("button", { name: /custom range/i }).textContent,
+    ).toContain("Custom range");
+  });
+
+  it("shifts a range by its exact duration in both directions", () => {
+    const onShiftRange = vi.fn();
+    const range = { start: 1_000n, end: 3_500n };
+    const { rerender } = render(
+      <TimeRangeDropdown
+        onSelectRange={mockOnSelectRange}
+        onShiftRange={onShiftRange}
+        currentRange={range}
+      />,
+    );
+
+    const controls = screen.getByRole("group", {
+      name: "Time range shift controls",
+    });
+    expect(controls.children).toHaveLength(3);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Previous time range" }),
+    );
+    expect(onShiftRange).toHaveBeenLastCalledWith(-1_500n, 1_000n);
+
+    rerender(
+      <TimeRangeDropdown
+        onSelectRange={mockOnSelectRange}
+        onShiftRange={onShiftRange}
+        currentRange={{ start: -1_500n, end: 1_000n }}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Next time range" }));
+    expect(onShiftRange).toHaveBeenLastCalledWith(1_000n, 3_500n);
+  });
+
+  it("disables shifts for undefined or invalid ranges", () => {
+    const { rerender } = render(
+      <TimeRangeDropdown onSelectRange={mockOnSelectRange} />,
+    );
+    const expectDisabled = () => {
+      expect(
+        screen.getByRole("button", { name: "Previous time range" }),
+      ).toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: "Next time range" }),
+      ).toBeDisabled();
+    };
+
+    expectDisabled();
+    rerender(
+      <TimeRangeDropdown
+        onSelectRange={mockOnSelectRange}
+        currentRange={{ start: 1n, end: 1n }}
+      />,
+    );
+    expectDisabled();
+    rerender(
+      <TimeRangeDropdown
+        onSelectRange={mockOnSelectRange}
+        currentRange={{ start: 2n, end: 1n }}
+      />,
+    );
+    expectDisabled();
+  });
+
+  it("displays a shifted relative range as custom", () => {
+    const relativeRange = getTimeRangeFromKey("last1");
+    const duration = relativeRange.end - relativeRange.start;
+    const { rerender } = render(
+      <TimeRangeDropdown
+        onSelectRange={mockOnSelectRange}
+        currentRange={relativeRange}
+      />,
+    );
+
+    rerender(
+      <TimeRangeDropdown
+        onSelectRange={mockOnSelectRange}
+        currentRange={{
+          start: relativeRange.start - duration,
+          end: relativeRange.end - duration,
+        }}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /custom range/i }).textContent,
+    ).toContain("Custom range");
   });
 });

--- a/src/Components/Entry/TimeRangeDropdown.tsx
+++ b/src/Components/Entry/TimeRangeDropdown.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { Button, DatePicker, Space, Grid, Dropdown } from "antd";
+import { Button, DatePicker, Space, Grid, Dropdown, Tooltip } from "antd";
 import type { MenuProps } from "antd";
-import { DownOutlined } from "@ant-design/icons";
+import { DownOutlined, LeftOutlined, RightOutlined } from "@ant-design/icons";
 import dayjs, { Dayjs } from "../../Helpers/dayjsConfig";
 import {
   getTimeRangeFromKey,
@@ -15,12 +15,14 @@ type RangeValue = Parameters<
 
 interface Props {
   onSelectRange: (start: bigint, end: bigint) => void;
+  onShiftRange?: (start: bigint, end: bigint) => void;
   initialRangeKey?: string;
   currentRange?: { start: bigint | undefined; end: bigint | undefined };
 }
 
 export default function TimeRangeDropdown({
   onSelectRange,
+  onShiftRange,
   initialRangeKey,
   currentRange,
 }: Props) {
@@ -86,6 +88,19 @@ export default function TimeRangeDropdown({
   };
 
   const displayLabel = rangeLabel || "Select time range";
+  const canShift =
+    currentRange?.start !== undefined &&
+    currentRange.end !== undefined &&
+    currentRange.end > currentRange.start;
+
+  const shiftRange = (direction: -1n | 1n) => {
+    if (!canShift || !currentRange) return;
+    const duration = currentRange.end! - currentRange.start!;
+    onShiftRange?.(
+      currentRange.start! + direction * duration,
+      currentRange.end! + direction * duration,
+    );
+  };
 
   const menuItems: MenuProps["items"] = presets.map((p) => ({
     key: p.key,
@@ -93,99 +108,123 @@ export default function TimeRangeDropdown({
   }));
 
   return (
-    <div style={{ display: "inline-block", position: "relative" }}>
-      {isSmall ? (
-        <Dropdown
-          open={menuOpen}
-          onOpenChange={(open) => setMenuOpen(open)}
-          menu={{
-            items: menuItems,
-            onClick: ({ key }) => {
-              handlePresetPick(String(key));
-              setMenuOpen(false);
-            },
-          }}
-          placement="bottomLeft"
-          trigger={["click"]}
-        >
-          <Button onClick={() => setMenuOpen(true)}>
-            {displayLabel}
-            <DownOutlined />
-          </Button>
-        </Dropdown>
-      ) : (
-        <>
-          <Button
-            onMouseDown={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              setPickerOpen((prev) => {
-                if (prev) {
-                  suppressNextOpen.current = true;
-                  return false;
-                }
-                return true;
-              });
+    <div
+      role="group"
+      aria-label="Time range shift controls"
+      style={{ display: "inline-flex", alignItems: "center", gap: 4 }}
+    >
+      <Tooltip title="Previous time range">
+        <Button
+          type="text"
+          icon={<LeftOutlined />}
+          aria-label="Previous time range"
+          disabled={!canShift}
+          onClick={() => shiftRange(-1n)}
+        />
+      </Tooltip>
+      <div style={{ display: "inline-block", position: "relative" }}>
+        {isSmall ? (
+          <Dropdown
+            open={menuOpen}
+            onOpenChange={(open) => setMenuOpen(open)}
+            menu={{
+              items: menuItems,
+              onClick: ({ key }) => {
+                handlePresetPick(String(key));
+                setMenuOpen(false);
+              },
             }}
+            placement="bottomLeft"
+            trigger={["click"]}
           >
-            {displayLabel}
-            <DownOutlined />
-          </Button>
-          <Space
-            orientation="vertical"
-            size={12}
-            style={{
-              position: "absolute",
-              insetInlineStart: 0,
-              top: 0,
-              width: 1,
-              height: 1,
-              padding: 0,
-              margin: 0,
-              border: 0,
-              opacity: 0,
-              pointerEvents: "none",
-              overflow: "hidden",
-            }}
-          >
-            <DatePicker.RangePicker
-              open={pickerOpen}
-              onOpenChange={(open) => {
-                if (!isMounted.current) return;
-                if (open && suppressNextOpen.current) {
-                  suppressNextOpen.current = false;
-                  return;
-                }
-                setPickerOpen(open);
-                if (!open) setTempDates(null);
+            <Button onClick={() => setMenuOpen(true)}>
+              {displayLabel}
+              <DownOutlined />
+            </Button>
+          </Dropdown>
+        ) : (
+          <>
+            <Button
+              onMouseDown={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setPickerOpen((prev) => {
+                  if (prev) {
+                    suppressNextOpen.current = true;
+                    return false;
+                  }
+                  return true;
+                });
               }}
-              value={tempDates}
-              onCalendarChange={(vals) => {
-                if (!isMounted.current) return;
-                const v = vals as RangeValue;
-                setTempDates(v);
+            >
+              {displayLabel}
+              <DownOutlined />
+            </Button>
+            <Space
+              orientation="vertical"
+              size={12}
+              style={{
+                position: "absolute",
+                insetInlineStart: 0,
+                top: 0,
+                width: 1,
+                height: 1,
+                padding: 0,
+                margin: 0,
+                border: 0,
+                opacity: 0,
+                pointerEvents: "none",
+                overflow: "hidden",
               }}
-              onChange={(dates) => {
-                if (!isMounted.current) return;
-                const from = dates?.[0] as Dayjs | null;
-                const to = dates?.[1] as Dayjs | null;
-                if (from && to) {
-                  applyRange(from, to);
-                  const key = detectRangeKey(
-                    BigInt(from.valueOf() * 1000),
-                    BigInt(to.valueOf() * 1000),
-                  );
-                  setRangeLabel(RANGE_MAP[key]);
-                }
-                setPickerOpen(false);
-              }}
-              presets={presets.map(({ label, value }) => ({ label, value }))}
-              allowClear={false}
-              showTime={false}
-            />
-          </Space>
-        </>
-      )}
+            >
+              <DatePicker.RangePicker
+                open={pickerOpen}
+                onOpenChange={(open) => {
+                  if (!isMounted.current) return;
+                  if (open && suppressNextOpen.current) {
+                    suppressNextOpen.current = false;
+                    return;
+                  }
+                  setPickerOpen(open);
+                  if (!open) setTempDates(null);
+                }}
+                value={tempDates}
+                onCalendarChange={(vals) => {
+                  if (!isMounted.current) return;
+                  const v = vals as RangeValue;
+                  setTempDates(v);
+                }}
+                onChange={(dates) => {
+                  if (!isMounted.current) return;
+                  const from = dates?.[0] as Dayjs | null;
+                  const to = dates?.[1] as Dayjs | null;
+                  if (from && to) {
+                    applyRange(from, to);
+                    const key = detectRangeKey(
+                      BigInt(from.valueOf() * 1000),
+                      BigInt(to.valueOf() * 1000),
+                    );
+                    setRangeLabel(RANGE_MAP[key]);
+                  }
+                  setPickerOpen(false);
+                }}
+                presets={presets.map(({ label, value }) => ({ label, value }))}
+                allowClear={false}
+                showTime={false}
+              />
+            </Space>
+          </>
+        )}
+      </div>
+      <Tooltip title="Next time range">
+        <Button
+          type="text"
+          icon={<RightOutlined />}
+          aria-label="Next time range"
+          disabled={!canShift}
+          onClick={() => shiftRange(1n)}
+        />
+      </Tooltip>
     </div>
   );
 }

--- a/src/Components/QueryPanel/QueryPanel.tsx
+++ b/src/Components/QueryPanel/QueryPanel.tsx
@@ -456,22 +456,25 @@ export default function QueryPanel({
         return;
       }
 
-      if (fetchCtrlRef.current) {
-        fetchCtrlRef.current.abort();
-      }
-
-      fetchCtrlRef.current = new AbortController();
-      const abortSignal = fetchCtrlRef.current.signal;
+      fetchCtrlRef.current?.abort();
+      const controller = new AbortController();
+      const abortSignal = controller.signal;
+      fetchCtrlRef.current = controller;
+      const isCurrentRequest = () => fetchCtrlRef.current === controller;
 
       setIsLoading(true);
       setShowCancel(false);
       if (cancelDelayRef.current) clearTimeout(cancelDelayRef.current);
-      cancelDelayRef.current = setTimeout(() => setShowCancel(true), 500);
+      const cancelDelay = setTimeout(() => {
+        if (isCurrentRequest()) setShowCancel(true);
+      }, 500);
+      cancelDelayRef.current = cancelDelay;
       setFetchError("");
       setRecords([]);
 
       try {
         const bucketInstance = await client.getBucket(bucketName);
+        if (!isCurrentRequest()) return;
         setBucket(bucketInstance);
 
         const options = new QueryOptions();
@@ -521,13 +524,9 @@ export default function QueryPanel({
           end,
           options,
         )) {
-          if (abortSignal.aborted) {
-            if (batch.length) {
-              setRecords((prev) => [...prev, ...batch]);
-            }
-            progress.cancel();
-            return;
-          }
+          if (!isCurrentRequest()) return;
+          if (abortSignal.aborted) break;
+
           batch.push({
             record,
             tableIndex: count,
@@ -546,17 +545,18 @@ export default function QueryPanel({
           }
         }
 
+        if (!isCurrentRequest()) return;
         if (batch.length) {
-          if (abortSignal.aborted) {
-            setRecords((prev) => [...prev, ...batch]);
-            progress.cancel();
-            return;
-          }
           setRecords((prev) => [...prev, ...batch]);
         }
 
-        progress.done();
+        if (abortSignal.aborted) {
+          progress.cancel();
+        } else {
+          progress.done();
+        }
       } catch (err) {
+        if (!isCurrentRequest()) return;
         if (abortSignal.aborted) {
           progress.cancel();
           return;
@@ -571,13 +571,15 @@ export default function QueryPanel({
           setFetchError("Failed to fetch records.");
         }
       } finally {
-        if (cancelDelayRef.current) {
-          clearTimeout(cancelDelayRef.current);
-          cancelDelayRef.current = null;
+        clearTimeout(cancelDelay);
+        if (isCurrentRequest()) {
+          if (cancelDelayRef.current === cancelDelay) {
+            cancelDelayRef.current = null;
+          }
+          setShowCancel(false);
+          setIsLoading(false);
+          fetchCtrlRef.current = null;
         }
-        setShowCancel(false);
-        setIsLoading(false);
-        fetchCtrlRef.current = null;
       }
     },
     [
@@ -1165,6 +1167,12 @@ export default function QueryPanel({
                       setTimeRange(start, end);
                       setStartError(false);
                       setStopError(false);
+                    }}
+                    onShiftRange={(start, end) => {
+                      setTimeRange(start, end);
+                      setStartError(false);
+                      setStopError(false);
+                      if (hasValidSelection) getRecords(start, end).then();
                     }}
                     initialRangeKey={DEFAULT_RANGE_KEY}
                     currentRange={{

--- a/src/Views/BucketPanel/EntryDetail.test.tsx
+++ b/src/Views/BucketPanel/EntryDetail.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, fireEvent, waitFor } from "@testing-library/react";
+import { render, fireEvent, screen, waitFor } from "@testing-library/react";
 import type { Mock } from "vitest";
 import { act } from "react";
 import { mockJSDOM } from "../../Helpers/TestHelpers";
@@ -959,6 +959,105 @@ describe("EntryDetail", () => {
         head: true,
         strict: true,
       });
+    });
+
+    it("shifts the time range and fetches the adjacent window", async () => {
+      (bucket.query as Mock).mockClear();
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: "Next time range" }),
+        );
+        vi.runOnlyPendingTimers();
+      });
+
+      expect(
+        container.querySelector('input[placeholder="Start time (optional)"]'),
+      ).toHaveValue("1970-01-01T01:00:00.000Z");
+      expect(
+        container.querySelector('input[placeholder="Stop time (optional)"]'),
+      ).toHaveValue("1970-01-01T02:00:00.000Z");
+      expect(bucket.query).toHaveBeenCalledWith(
+        "testEntry",
+        3_600_000_000n,
+        7_200_000_000n,
+        expect.objectContaining({
+          head: true,
+          strict: true,
+          when: expect.objectContaining({ $each_t: "30s" }),
+        }),
+      );
+    });
+
+    it("keeps the latest shifted query active when an earlier query completes", async () => {
+      let resolveFirstQuery!: () => void;
+      let resolveSecondQuery!: () => void;
+      const firstQuery = new Promise<void>((resolve) => {
+        resolveFirstQuery = resolve;
+      });
+      const secondQuery = new Promise<void>((resolve) => {
+        resolveSecondQuery = resolve;
+      });
+      let queryNumber = 0;
+      bucket.query = vi.fn().mockImplementation(() => {
+        const currentQuery = ++queryNumber;
+        return {
+          async *[Symbol.asyncIterator]() {
+            await (currentQuery === 1 ? firstQuery : secondQuery);
+            yield {
+              ...mockRecords[0],
+              key: `query-${currentQuery}`,
+              labels: { query: `${currentQuery}` },
+            };
+          },
+        };
+      });
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: "Next time range" }),
+        );
+      });
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: "Next time range" }),
+        );
+      });
+
+      expect(bucket.query).toHaveBeenLastCalledWith(
+        "testEntry",
+        7_200_000_000n,
+        10_800_000_000n,
+        expect.anything(),
+      );
+
+      await act(async () => {
+        vi.advanceTimersByTime(600);
+      });
+      expect(container.querySelector(".fetchButton button")!.textContent).toBe(
+        "Stop",
+      );
+
+      await act(async () => {
+        resolveFirstQuery();
+        await Promise.resolve();
+      });
+      expect(container.querySelector(".fetchButton button")!.textContent).toBe(
+        "Stop",
+      );
+
+      await act(async () => {
+        resolveSecondQuery();
+        await Promise.resolve();
+      });
+      await waitFor(() => {
+        expect(container.querySelectorAll(".ant-table-row")).toHaveLength(1);
+      });
+      expect(container.textContent).toContain("query: 2");
+      expect(container.textContent).not.toContain("query: 1");
+      expect(container.querySelector(".fetchButton button")!.textContent).toBe(
+        "Fetch Records",
+      );
     });
   });
 

--- a/src/Views/BucketPanel/EntryDetail.test.tsx
+++ b/src/Views/BucketPanel/EntryDetail.test.tsx
@@ -987,7 +987,7 @@ describe("EntryDetail", () => {
           when: expect.objectContaining({ $each_t: "30s" }),
         }),
       );
-    });
+    }, 10_000);
 
     it("keeps the latest shifted query active when an earlier query completes", async () => {
       let resolveFirstQuery!: () => void;
@@ -1058,7 +1058,7 @@ describe("EntryDetail", () => {
       expect(container.querySelector(".fetchButton button")!.textContent).toBe(
         "Fetch Records",
       );
-    });
+    }, 10_000);
   });
 
   describe("Sub-entry Warning", () => {


### PR DESCRIPTION
Closes #196

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

- Added previous and next controls beside the query time-range selector.
- Shifted ranges retain their exact duration and update the active query immediately.
- Guarded asynchronous query cleanup by request ownership so an older, aborted query cannot overwrite loading, cancellation, progress, or results state for a newer query.
- Added component and integration coverage for range shifting and overlapping queries.

### Related issues

https://github.com/reductstore/web-console/issues/196

### Does this PR introduce a breaking change?

No.

### Other information:

The current changelog entry references the issue; it will be updated to reference this PR after creation.
