### PR TITLE
Improve query range presets and JSON editor resizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support wire compression settings for replications, [PR-226](https://github.com/reductstore/web-console/pull/226)
 - Support lifecycle processing intervals, [PR-227](https://github.com/reductstore/web-console/pull/227)
 - Add previous and next controls for shifting query time ranges, [PR-228](https://github.com/reductstore/web-console/pull/228)
+- Add short query range presets and vertically resizable JSON query editors, [PR-241](https://github.com/reductstore/web-console/pull/241)
 
 ## 1.15.1 - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.16.0 - 2026-08-25
+
 ### Added
 
 - Support destination entry prefixes for replications, [PR-225](https://github.com/reductstore/web-console/pull/225)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-console",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-console",
-      "version": "1.15.1",
+      "version": "1.16.0",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
         "@reductstore/reduct-query-monaco": "^1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4024,9 +4024,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-console",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "type": "module",
   "private": true,
   "devDependencies": {

--- a/src/Components/Entry/TimeRangeDropdown.css
+++ b/src/Components/Entry/TimeRangeDropdown.css
@@ -1,0 +1,14 @@
+.timeRangePresetMenu .ant-dropdown-menu {
+  max-height: min(60vh, 420px);
+  overflow-y: auto;
+}
+
+.timeRangePickerPopup .ant-picker-presets {
+  max-height: min(60vh, 420px);
+  overflow: hidden;
+}
+
+.timeRangePickerPopup .ant-picker-presets ul {
+  max-height: inherit;
+  overflow-y: auto;
+}

--- a/src/Components/Entry/TimeRangeDropdown.test.tsx
+++ b/src/Components/Entry/TimeRangeDropdown.test.tsx
@@ -2,7 +2,8 @@ import { render, screen, fireEvent, act } from "@testing-library/react";
 import TimeRangeDropdown from "./TimeRangeDropdown";
 import { mockJSDOM } from "../../Helpers/TestHelpers";
 import dayjs from "dayjs";
-import { getTimeRangeFromKey } from "../../Helpers/timeRangeUtils";
+import { Grid } from "antd";
+import { getTimeRangeFromKey, RANGE_MAP } from "../../Helpers/timeRangeUtils";
 
 describe("TimeRangeDropdown", () => {
   beforeEach(() => {
@@ -12,6 +13,10 @@ describe("TimeRangeDropdown", () => {
       unobserve() {}
       disconnect() {}
     };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   const mockOnSelectRange = vi.fn();
@@ -34,6 +39,71 @@ describe("TimeRangeDropdown", () => {
     expect(
       screen.getByRole("button", { name: /custom range/i }).textContent,
     ).toContain("Custom range");
+  });
+
+  it("renders Last 1 hour as the configured initial range", () => {
+    render(
+      <TimeRangeDropdown
+        onSelectRange={mockOnSelectRange}
+        initialRangeKey="last1"
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /last 1 hour/i }).textContent,
+    ).toContain("Last 1 hour");
+  });
+
+  it.each([
+    ["Last 5 minutes", 5n],
+    ["Last 15 minutes", 15n],
+    ["Last 30 minutes", 30n],
+  ])("selects %s with its exact duration", async (label, minutes) => {
+    mockOnSelectRange.mockClear();
+    render(<TimeRangeDropdown onSelectRange={mockOnSelectRange} />);
+
+    await openMenuAndClick(label);
+
+    const [start, end] = mockOnSelectRange.mock.calls[0] || [];
+    expect(end - start).toBe(minutes * 60n * 1_000_000n);
+  });
+
+  it("shows presets in map order and applies the mobile scroll hook", async () => {
+    render(<TimeRangeDropdown onSelectRange={mockOnSelectRange} />);
+
+    await act(async () => {
+      fireEvent.click(
+        screen
+          .getAllByRole("button")
+          .find((button) => !button.hasAttribute("aria-label"))!,
+      );
+    });
+
+    const menu = document.querySelector(".timeRangePresetMenu");
+    expect(menu).not.toBeNull();
+    const labels = Array.from(
+      menu!.querySelectorAll(".ant-dropdown-menu-title-content"),
+    ).map((item) => item.textContent);
+    expect(labels).toEqual(
+      Object.entries(RANGE_MAP)
+        .filter(([key]) => key !== "custom")
+        .map(([, label]) => label),
+    );
+  });
+
+  it("applies the desktop picker scroll hook", async () => {
+    vi.spyOn(Grid, "useBreakpoint").mockReturnValue({ md: true });
+    render(<TimeRangeDropdown onSelectRange={mockOnSelectRange} />);
+
+    await act(async () => {
+      fireEvent.mouseDown(
+        screen
+          .getAllByRole("button")
+          .find((button) => !button.hasAttribute("aria-label"))!,
+      );
+    });
+
+    expect(document.querySelector(".timeRangePickerPopup")).not.toBeNull();
   });
 
   it("triggers onSelectRange for 'Last 1 hour'", async () => {
@@ -197,6 +267,20 @@ describe("TimeRangeDropdown", () => {
     expect(
       screen.getByRole("button", { name: /last 7 days/i }).textContent,
     ).toContain("Last 7 days");
+  });
+
+  it("detects a short preset label from currentRange", () => {
+    const last15Range = getTimeRangeFromKey("last15m");
+    render(
+      <TimeRangeDropdown
+        onSelectRange={mockOnSelectRange}
+        currentRange={last15Range}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /last 15 minutes/i }).textContent,
+    ).toContain("Last 15 minutes");
   });
 
   it("displays 'Custom range' for unmatched currentRange", () => {

--- a/src/Components/Entry/TimeRangeDropdown.tsx
+++ b/src/Components/Entry/TimeRangeDropdown.tsx
@@ -8,6 +8,7 @@ import {
   RANGE_MAP,
   detectRangeKey,
 } from "../../Helpers/timeRangeUtils";
+import "./TimeRangeDropdown.css";
 
 type RangeValue = Parameters<
   NonNullable<React.ComponentProps<typeof DatePicker.RangePicker>["onChange"]>
@@ -29,7 +30,7 @@ export default function TimeRangeDropdown({
   const [pickerOpen, setPickerOpen] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const [rangeLabel, setRangeLabel] = useState<string | undefined>(
-    initialRangeKey ? RANGE_MAP[initialRangeKey] : undefined,
+    RANGE_MAP[initialRangeKey ?? "custom"],
   );
   const [tempDates, setTempDates] = useState<RangeValue>(null);
 
@@ -47,6 +48,7 @@ export default function TimeRangeDropdown({
   }, []);
 
   useEffect(() => {
+    if (!currentRange) return;
     const detectedKey = detectRangeKey(currentRange?.start, currentRange?.end);
     setRangeLabel(RANGE_MAP[detectedKey]);
   }, [currentRange]);
@@ -127,6 +129,7 @@ export default function TimeRangeDropdown({
           <Dropdown
             open={menuOpen}
             onOpenChange={(open) => setMenuOpen(open)}
+            classNames={{ root: "timeRangePresetMenu" }}
             menu={{
               items: menuItems,
               onClick: ({ key }) => {
@@ -179,6 +182,9 @@ export default function TimeRangeDropdown({
             >
               <DatePicker.RangePicker
                 open={pickerOpen}
+                classNames={{
+                  popup: { root: "timeRangePickerPopup" },
+                }}
                 onOpenChange={(open) => {
                   if (!isMounted.current) return;
                   if (open && suppressNextOpen.current) {

--- a/src/Components/JsonEditor/JsonQueryEditor.css
+++ b/src/Components/JsonEditor/JsonQueryEditor.css
@@ -12,6 +12,50 @@
   height: 100%;
 }
 
+.jsonQueryEditorContainer.isResizable .jsonQueryEditorToolbar {
+  border-radius: 0;
+}
+
+.jsonQueryEditorResizeHandle {
+  position: relative;
+  flex: 0 0 10px;
+  border-radius: 0 0 6px 6px;
+  background: #fafafa;
+  cursor: row-resize;
+  touch-action: none;
+  outline: none;
+}
+
+.jsonQueryEditorResizeHandle span {
+  position: absolute;
+  top: 3px;
+  left: 50%;
+  width: 32px;
+  height: 3px;
+  border-radius: 2px;
+  background: #bfbfbf;
+  transform: translateX(-50%);
+  transition:
+    width 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.jsonQueryEditorResizeHandle:hover span,
+.jsonQueryEditorResizeHandle:focus-visible span {
+  width: 44px;
+  background: var(--input-focus);
+}
+
+.jsonQueryEditorResizeHandle:focus-visible {
+  box-shadow: inset 0 0 0 2px var(--input-focus);
+}
+
+.jsonQueryEditorContainer.isResizing,
+.jsonQueryEditorContainer.isResizing * {
+  cursor: row-resize !important;
+  user-select: none;
+}
+
 .jsonQueryEditorToolbar {
   display: flex;
   align-items: center;
@@ -119,4 +163,14 @@
 
 .jsonQueryEditor .monaco-editor .suggest-widget {
   z-index: 1000;
+}
+
+@media (max-width: 480px) {
+  .jsonQueryEditorResizeHandle {
+    flex-basis: 12px;
+  }
+
+  .jsonQueryEditorResizeHandle span {
+    top: 4px;
+  }
 }

--- a/src/Components/JsonEditor/JsonQueryEditor.test.tsx
+++ b/src/Components/JsonEditor/JsonQueryEditor.test.tsx
@@ -110,6 +110,134 @@ describe("JsonQueryEditor", () => {
     ).toBeInTheDocument();
   });
 
+  it("resizes with the keyboard and clamps to its bounds", () => {
+    render(<JsonQueryEditor value="{}" onChange={() => {}} height={140} />);
+    const handle = screen.getByRole("separator", {
+      name: "Resize JSON editor",
+    });
+    const container = handle.parentElement!;
+
+    expect(container).toHaveStyle({ height: "140px" });
+    expect(handle).toHaveAttribute("aria-valuenow", "140");
+
+    fireEvent.keyDown(handle, { key: "ArrowDown" });
+    expect(container).toHaveStyle({ height: "156px" });
+
+    for (let i = 0; i < 10; i += 1) {
+      fireEvent.keyDown(handle, { key: "ArrowUp" });
+    }
+    expect(container).toHaveStyle({ height: "100px" });
+    expect(handle).toHaveAttribute("aria-valuenow", "100");
+
+    for (let i = 0; i < 100; i += 1) {
+      fireEvent.keyDown(handle, { key: "ArrowDown" });
+    }
+    const maximum = handle.getAttribute("aria-valuemax");
+    expect(container).toHaveStyle({ height: `${maximum}px` });
+    expect(handle).toHaveAttribute("aria-valuenow", maximum);
+  });
+
+  it("resizes by pointer drag and removes listeners on completion", () => {
+    render(<JsonQueryEditor value="{}" onChange={() => {}} height={140} />);
+    const handle = screen.getByRole("separator", {
+      name: "Resize JSON editor",
+    });
+    const container = handle.parentElement!;
+    vi.spyOn(container, "getBoundingClientRect").mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      right: 0,
+      bottom: 140,
+      left: 0,
+      width: 0,
+      height: 140,
+      toJSON: () => ({}),
+    });
+    const removeListener = vi.spyOn(window, "removeEventListener");
+
+    fireEvent.pointerDown(handle, {
+      button: 0,
+      pointerId: 1,
+      clientY: 100,
+    });
+    fireEvent.pointerMove(window, { pointerId: 1, clientY: 180 });
+    expect(container).toHaveStyle({ height: "220px" });
+
+    fireEvent.pointerUp(window, { pointerId: 1 });
+    expect(removeListener).toHaveBeenCalledWith(
+      "pointermove",
+      expect.any(Function),
+    );
+  });
+
+  it("keeps following height props until a manual resize", () => {
+    const { rerender } = render(
+      <JsonQueryEditor value="{}" onChange={() => {}} height={120} />,
+    );
+    const handle = screen.getByRole("separator", {
+      name: "Resize JSON editor",
+    });
+
+    rerender(<JsonQueryEditor value="{}" onChange={() => {}} height={180} />);
+    expect(handle.parentElement).toHaveStyle({ height: "180px" });
+
+    fireEvent.keyDown(handle, { key: "ArrowDown" });
+    expect(handle.parentElement).toHaveStyle({ height: "196px" });
+
+    rerender(
+      <JsonQueryEditor
+        value={'{\n  "changed": true\n}'}
+        onChange={() => {}}
+        height={300}
+      />,
+    );
+    expect(handle.parentElement).toHaveStyle({ height: "196px" });
+  });
+
+  it("keeps the expanded editor full-height without a resize handle", () => {
+    render(<JsonQueryEditor value="{}" onChange={() => {}} height={120} />);
+    const handle = screen.getByRole("separator", {
+      name: "Resize JSON editor",
+    });
+    fireEvent.keyDown(handle, { key: "ArrowDown" });
+
+    fireEvent.click(screen.getByLabelText("Expand editor"));
+
+    expect(
+      screen.queryByRole("separator", { name: "Resize JSON editor" }),
+    ).not.toBeInTheDocument();
+    expect(
+      document.querySelector(
+        ".jsonQueryEditorModalContent .jsonQueryEditorContainer",
+      ),
+    ).toHaveStyle({ height: "100%" });
+
+    fireEvent.click(screen.getByLabelText("Collapse editor"));
+    expect(
+      screen.getByRole("separator", { name: "Resize JSON editor" })
+        .parentElement,
+    ).toHaveStyle({ height: "136px" });
+  });
+
+  it("starts from the supplied height after remounting", () => {
+    const first = render(
+      <JsonQueryEditor value="{}" onChange={() => {}} height={120} />,
+    );
+    fireEvent.keyDown(
+      screen.getByRole("separator", { name: "Resize JSON editor" }),
+      { key: "ArrowDown" },
+    );
+    first.unmount();
+
+    render(<JsonQueryEditor value="{}" onChange={() => {}} height={220} />);
+
+    expect(
+      screen.getByRole("separator", { name: "Resize JSON editor" })
+        .parentElement,
+    ).toHaveStyle({ height: "220px" });
+  });
+
   it("passes start/stop into the validation query", async () => {
     const queryNext = vi.fn().mockResolvedValue({ done: true });
     const query = vi.fn().mockReturnValue({ next: queryNext });

--- a/src/Components/JsonEditor/JsonQueryEditor.tsx
+++ b/src/Components/JsonEditor/JsonQueryEditor.tsx
@@ -22,6 +22,10 @@ enum ValidationStatus {
   Invalid = "invalid",
 }
 
+const MIN_INLINE_EDITOR_HEIGHT = 100;
+const MAX_INLINE_EDITOR_VIEWPORT_RATIO = 0.8;
+const KEYBOARD_RESIZE_STEP = 16;
+
 interface ValidationContext {
   client: Client;
   bucket?: string;
@@ -76,7 +80,11 @@ export function JsonQueryEditor({
   toolbarExtra,
 }: JsonQueryEditorProps) {
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
+  const inlineContainerRef = useRef<HTMLDivElement | null>(null);
+  const stopPointerResizeRef = useRef<(() => void) | null>(null);
   const [isExpanded, setIsExpanded] = useState(false);
+  const [isResizing, setIsResizing] = useState(false);
+  const [manualHeight, setManualHeight] = useState<number | undefined>();
   const [validationStatus, setValidationStatus] = useState<ValidationStatus>(
     ValidationStatus.Idle,
   );
@@ -163,7 +171,108 @@ export function JsonQueryEditor({
     setIsExpanded((prev) => !prev);
   };
 
-  const containerHeight = typeof height === "number" ? `${height}px` : height;
+  const getMaximumEditorHeight = () =>
+    Math.max(
+      MIN_INLINE_EDITOR_HEIGHT,
+      Math.floor(window.innerHeight * MAX_INLINE_EDITOR_VIEWPORT_RATIO),
+    );
+
+  const clampEditorHeight = (nextHeight: number) =>
+    Math.min(
+      getMaximumEditorHeight(),
+      Math.max(MIN_INLINE_EDITOR_HEIGHT, Math.round(nextHeight)),
+    );
+
+  const getRenderedInlineHeight = () => {
+    const container = inlineContainerRef.current;
+    const renderedHeight = container?.getBoundingClientRect().height ?? 0;
+    if (renderedHeight > 0) return renderedHeight;
+    if (container && container.offsetHeight > 0) return container.offsetHeight;
+    if (manualHeight !== undefined) return manualHeight;
+    if (typeof height === "number") return height;
+    if (height.endsWith("px")) return Number.parseFloat(height);
+    return MIN_INLINE_EDITOR_HEIGHT;
+  };
+
+  const handleResizePointerDown = (
+    event: React.PointerEvent<HTMLDivElement>,
+  ) => {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    stopPointerResizeRef.current?.();
+
+    const { currentTarget: handle, pointerId, clientY: startY } = event;
+    const startHeight = clampEditorHeight(getRenderedInlineHeight());
+    setManualHeight(startHeight);
+    setIsResizing(true);
+
+    try {
+      handle.setPointerCapture?.(pointerId);
+    } catch {
+      // Pointer capture is optional in older browsers and test environments.
+    }
+
+    const handlePointerMove = (pointerEvent: PointerEvent) => {
+      if (pointerEvent.pointerId !== pointerId) return;
+      setManualHeight(
+        clampEditorHeight(startHeight + pointerEvent.clientY - startY),
+      );
+    };
+
+    const stopPointerResize = () => {
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerEnd);
+      window.removeEventListener("pointercancel", handlePointerEnd);
+      try {
+        if (handle.hasPointerCapture?.(pointerId)) {
+          handle.releasePointerCapture(pointerId);
+        }
+      } catch {
+        // The handle may have been removed while a drag was active.
+      }
+      stopPointerResizeRef.current = null;
+    };
+
+    const handlePointerEnd = (pointerEvent: PointerEvent) => {
+      if (pointerEvent.pointerId !== pointerId) return;
+      stopPointerResize();
+      setIsResizing(false);
+    };
+
+    stopPointerResizeRef.current = stopPointerResize;
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", handlePointerEnd);
+    window.addEventListener("pointercancel", handlePointerEnd);
+  };
+
+  const handleResizeKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return;
+    event.preventDefault();
+    const direction = event.key === "ArrowUp" ? -1 : 1;
+    setManualHeight((currentHeight) =>
+      clampEditorHeight(
+        (currentHeight ?? getRenderedInlineHeight()) +
+          direction * KEYBOARD_RESIZE_STEP,
+      ),
+    );
+  };
+
+  const effectiveHeight = manualHeight ?? height;
+  const containerHeight =
+    typeof effectiveHeight === "number"
+      ? `${effectiveHeight}px`
+      : effectiveHeight;
+  const currentHeight = Math.round(
+    manualHeight ??
+      (typeof height === "number" ? height : MIN_INLINE_EDITOR_HEIGHT),
+  );
+
+  useEffect(
+    () => () => {
+      stopPointerResizeRef.current?.();
+    },
+    [],
+  );
 
   useEffect(() => {
     const parsed = processWhenCondition(value, validationIntervalValue);
@@ -387,8 +496,15 @@ export function JsonQueryEditor({
     return null;
   };
 
-  const renderEditorShell = (style?: React.CSSProperties) => (
-    <div className="jsonQueryEditorContainer" style={style}>
+  const renderEditorShell = (
+    style?: React.CSSProperties,
+    resizable = false,
+  ) => (
+    <div
+      ref={resizable ? inlineContainerRef : undefined}
+      className={`jsonQueryEditorContainer${resizable ? " isResizable" : ""}${isResizing ? " isResizing" : ""}`}
+      style={style}
+    >
       <div className="jsonQueryEditorBody">
         <Editor
           height="100%"
@@ -465,6 +581,22 @@ export function JsonQueryEditor({
           </Tooltip>
         </div>
       </div>
+      {resizable && (
+        <div
+          className="jsonQueryEditorResizeHandle"
+          role="separator"
+          aria-label="Resize JSON editor"
+          aria-orientation="horizontal"
+          aria-valuemin={MIN_INLINE_EDITOR_HEIGHT}
+          aria-valuemax={getMaximumEditorHeight()}
+          aria-valuenow={currentHeight}
+          tabIndex={0}
+          onPointerDown={handleResizePointerDown}
+          onKeyDown={handleResizeKeyDown}
+        >
+          <span aria-hidden="true" />
+        </div>
+      )}
     </div>
   );
 
@@ -478,7 +610,7 @@ export function JsonQueryEditor({
           Editing in expanded JSON editor
         </div>
       ) : (
-        renderEditorShell({ height: containerHeight })
+        renderEditorShell({ height: containerHeight }, true)
       )}
       {isExpanded && (
         <Modal

--- a/src/Helpers/timeRangeUtils.test.ts
+++ b/src/Helpers/timeRangeUtils.test.ts
@@ -11,6 +11,19 @@ describe("timeRangeUtils", () => {
   const mockNow = dayjs("2023-10-15T12:00:00Z");
 
   describe("getTimeRangeFromKey", () => {
+    it.each([
+      ["last5m", 5],
+      ["last15m", 15],
+      ["last30m", 30],
+    ])("should calculate %s in minutes correctly", (key, minutes) => {
+      const result = getTimeRangeFromKey(key, mockNow);
+
+      expect(result.start).toBe(
+        BigInt(mockNow.subtract(minutes, "minute").valueOf() * 1000),
+      );
+      expect(result.end).toBe(BigInt(mockNow.valueOf() * 1000));
+    });
+
     it("should calculate last1 range correctly", () => {
       const result = getTimeRangeFromKey("last1", mockNow);
       const expectedStart = BigInt(
@@ -88,6 +101,9 @@ describe("timeRangeUtils", () => {
   describe("RANGE_MAP", () => {
     it("should contain all expected range keys", () => {
       const expectedKeys = [
+        "last5m",
+        "last15m",
+        "last30m",
         "last1",
         "last6",
         "last24",
@@ -102,14 +118,20 @@ describe("timeRangeUtils", () => {
         "custom",
       ];
 
-      expectedKeys.forEach((key) => {
-        expect(RANGE_MAP[key]).toBeDefined();
-        expect(typeof RANGE_MAP[key]).toBe("string");
-      });
+      expect(Object.keys(RANGE_MAP)).toEqual(expectedKeys);
     });
   });
 
   describe("detectRangeKey", () => {
+    it.each(["last5m", "last15m", "last30m"])(
+      "should detect an exact %s range",
+      (key) => {
+        const range = getTimeRangeFromKey(key, mockNow);
+
+        expect(detectRangeKey(range.start, range.end, 10, mockNow)).toBe(key);
+      },
+    );
+
     it("should detect exact matches for preset ranges", () => {
       const last24Range = getTimeRangeFromKey("last24", mockNow);
       const detectedKey = detectRangeKey(
@@ -132,6 +154,22 @@ describe("timeRangeUtils", () => {
         mockNow,
       );
       expect(detectedKey).toBe("last1");
+    });
+
+    it("should select the nearest preset within the margin", () => {
+      const last15Range = getTimeRangeFromKey("last15m", mockNow);
+      const adjustedStart = last15Range.start + 4n * 60n * 1_000_000n;
+
+      expect(detectRangeKey(adjustedStart, last15Range.end, 10, mockNow)).toBe(
+        "last15m",
+      );
+    });
+
+    it("should return 'custom' for equally close preset matches", () => {
+      const end = BigInt(mockNow.valueOf() * 1000);
+      const start = BigInt(mockNow.subtract(10, "minute").valueOf() * 1000);
+
+      expect(detectRangeKey(start, end, 10, mockNow)).toBe("custom");
     });
 
     it("should return 'custom' for ranges outside margin of error", () => {

--- a/src/Helpers/timeRangeUtils.ts
+++ b/src/Helpers/timeRangeUtils.ts
@@ -6,6 +6,9 @@ export interface TimeRange {
 }
 
 export const RANGE_MAP: Record<string, string> = {
+  last5m: "Last 5 minutes",
+  last15m: "Last 15 minutes",
+  last30m: "Last 30 minutes",
   last1: "Last 1 hour",
   last6: "Last 6 hours",
   last24: "Last 24 hours",
@@ -39,6 +42,21 @@ export function getTimeRangeFromKey(
     BigInt(date.valueOf() * 1000);
 
   switch (key) {
+    case "last5m":
+      return {
+        start: convertToMicroseconds(now.subtract(5, "minute")),
+        end: convertToMicroseconds(now),
+      };
+    case "last15m":
+      return {
+        start: convertToMicroseconds(now.subtract(15, "minute")),
+        end: convertToMicroseconds(now),
+      };
+    case "last30m":
+      return {
+        start: convertToMicroseconds(now.subtract(30, "minute")),
+        end: convertToMicroseconds(now),
+      };
     case "last1":
       return {
         start: convertToMicroseconds(now.subtract(1, "hour")),
@@ -140,6 +158,8 @@ export function detectRangeKey(
   }
   const marginMicroseconds = BigInt(marginMinutes * 60 * 1000 * 1000);
   const presetKeys = Object.keys(RANGE_MAP).filter((key) => key !== "custom");
+  let closestMatch: { key: string; delta: bigint } | undefined;
+  let hasClosestMatchTie = false;
 
   for (const key of presetKeys) {
     try {
@@ -155,12 +175,18 @@ export function detectRangeKey(
           : expectedRange.end - end;
 
       if (startDiff <= marginMicroseconds && endDiff <= marginMicroseconds) {
-        return key;
+        const delta = startDiff + endDiff;
+        if (!closestMatch || delta < closestMatch.delta) {
+          closestMatch = { key, delta };
+          hasClosestMatchTie = false;
+        } else if (delta === closestMatch.delta) {
+          hasClosestMatchTie = true;
+        }
       }
     } catch {
       continue;
     }
   }
 
-  return "custom";
+  return closestMatch && !hasClosestMatchTie ? closestMatch.key : "custom";
 }


### PR DESCRIPTION
Closes #207

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (not required for this UI change)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

- Added Last 5 minutes, Last 15 minutes, and Last 30 minutes query presets while preserving Last 1 hour as the default and existing saved range keys.
- Made tolerant range detection choose the nearest preset and treat equally close matches as custom ranges.
- Added viewport-bounded scrolling to mobile and desktop time-range preset surfaces.
- Made all inline JSON query editors vertically resizable by pointer or keyboard while preserving automatic initial sizing and expanded-editor behavior.
- Added coverage for preset durations, ordering, detection, popup hooks, resize clamping, manual override behavior, expansion, and remounting.

### Related issues

#207

### Does this PR introduce a breaking change?

No.

### Other information:

Validation performed:

- `npm run fmt`
- `npm run typecheck`
- `npm run lint`
- Changed feature suites: 57 tests passed
- The full local Vitest run discovered tests inside `.kilo/node_modules`; an unrelated load-sensitive `BucketDetail` timeout passed when rerun in isolation.
